### PR TITLE
feat(blob): proxy-first blob serving with per-vulnerability ACL + F-1..F-7 pentest fixes

### DIFF
--- a/api/database/db.go
+++ b/api/database/db.go
@@ -93,11 +93,21 @@ type AssessmentJSON struct {
 	Assessment datatypes.JSON
 }
 
-// ImageData is a model for storing image metadata and binary data
+// ImageData is a model for storing image metadata and binary data.
+// Data holds the original upload; ProxyData holds a downscaled copy
+// served to non-creators. OwnerType/OwnerID link the blob to the
+// resource it was uploaded for ("vulnerability" or "note"), which is
+// the basis for access control.
 type ImageData struct {
 	gorm.Model
-	Filename string
-	Data     []byte
+	Filename       string `gorm:"index"`
+	Data           []byte
+	Mime           string
+	ProxyData      []byte
+	ProxyMime      string
+	UploaderEmail  string `gorm:"index"`
+	OwnerType      string `gorm:"index"` // "vulnerability" | "note" | ""
+	OwnerID        uint   `gorm:"index"`
 }
 
 type SlackSettings struct {
@@ -2116,10 +2126,28 @@ func GetProjectVulnerabilities(projectID uint, dateFrom, dateTo string) ([]JSOND
 }
 
 func SaveImage(filename string, data []byte) error {
-	// Create an ImageData instance
 	img := ImageData{Filename: filename, Data: data}
-	// Save to database
 	return db.Create(&img).Error
+}
+
+// SaveImageFull persists both original + proxy along with ownership metadata.
+func SaveImageFull(img *ImageData) error {
+	return db.Create(img).Error
+}
+
+// UpdateImageMeta updates ownership/proxy fields on an existing ImageData
+// (used by the backfill goroutine).
+func UpdateImageMeta(filename string, fields map[string]interface{}) error {
+	return db.Model(&ImageData{}).Where("filename = ?", filename).Updates(fields).Error
+}
+
+// ListImagesMissingProxy returns image rows that still need a proxy generated
+// or owner metadata populated.
+func ListImagesMissingProxy() ([]ImageData, error) {
+	var rows []ImageData
+	err := db.Where("proxy_data IS NULL OR length(proxy_data) = 0 OR owner_type = '' OR owner_type IS NULL").
+		Find(&rows).Error
+	return rows, err
 }
 
 func DeleteImage(filename string) error {

--- a/api/database/imageproxy.go
+++ b/api/database/imageproxy.go
@@ -1,0 +1,205 @@
+package database
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/jpeg"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+
+	_ "image/gif" // register gif decoder
+	_ "image/png" // register png decoder
+
+	webpencoder "github.com/HugoSmits86/nativewebp"
+	"golang.org/x/image/draw"
+	_ "golang.org/x/image/webp" // register webp decoder
+)
+
+const (
+	proxyMaxEdge     = 1080
+	proxyJPEGQuality = 82
+)
+
+var ErrUnsupportedImage = errors.New("unsupported image format")
+
+// DetectMime sniffs the image MIME from the first bytes (avoids trusting
+// the multipart header). Returns "" if not a recognised image type.
+func DetectMime(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	m := http.DetectContentType(data)
+	// http.DetectContentType handles png/jpeg/gif/webp. Return only the
+	// content-type prefix, stripping any charset info.
+	if i := strings.Index(m, ";"); i >= 0 {
+		m = strings.TrimSpace(m[:i])
+	}
+	return m
+}
+
+// GenerateProxy decodes the input image, downscales the long edge to at most
+// proxyMaxEdge (no upscale), strips EXIF by re-encoding, and returns WebP
+// bytes. If WebP encoding fails it falls back to JPEG.
+func GenerateProxy(data []byte, mime string) ([]byte, string, error) {
+	img, err := decodeImage(data, mime)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resized := resizeLongEdge(img, proxyMaxEdge)
+
+	// Prefer WebP (nativewebp is lossless VP8L — quality isn't configurable,
+	// but the resize step caps size).
+	var buf bytes.Buffer
+	if err := webpencoder.Encode(&buf, resized, nil); err == nil {
+		return buf.Bytes(), "image/webp", nil
+	}
+
+	// Fallback: JPEG (lossy) for photos, PNG for small diagrams would be nicer
+	// but JPEG is a safe single-branch fallback.
+	buf.Reset()
+	if err := jpeg.Encode(&buf, resized, &jpeg.Options{Quality: proxyJPEGQuality}); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), "image/jpeg", nil
+}
+
+func decodeImage(data []byte, mime string) (image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, ErrUnsupportedImage
+	}
+	return img, nil
+}
+
+// BackfillImages scans for legacy ImageData rows that lack owner metadata
+// and/or a proxy and fills them in:
+//   - Owner: for each row, search vulnerabilities' JSON content for the
+//     filename; if found, bind the blob to that vulnerability and the
+//     vulnerability's creator (FoundBy) as uploader.
+//   - Proxy: decode the original bytes and generate a WebP proxy.
+//
+// Designed to be called once in a background goroutine from main(). Logs but
+// does not return errors per-row.
+func BackfillImages() {
+	rows, err := ListImagesMissingProxy()
+	if err != nil {
+		log.Printf("BackfillImages: list failed: %v", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	log.Printf("BackfillImages: starting on %d image(s)", len(rows))
+	processed := 0
+	for _, row := range rows {
+		fields := map[string]interface{}{}
+
+		// Owner resolution.
+		if row.OwnerType == "" {
+			vuln, found := findVulnReferencing(row.Filename)
+			if found {
+				fields["owner_type"] = "vulnerability"
+				fields["owner_id"] = vuln.ID
+				if row.UploaderEmail == "" {
+					fields["uploader_email"] = vuln.FoundBy
+				}
+			}
+		}
+
+		// Proxy generation.
+		if len(row.ProxyData) == 0 && len(row.Data) > 0 {
+			mime := row.Mime
+			if mime == "" {
+				mime = DetectMime(row.Data)
+				if mime != "" {
+					fields["mime"] = mime
+				}
+			}
+			proxy, proxyMime, perr := GenerateProxy(row.Data, mime)
+			if perr == nil {
+				fields["proxy_data"] = proxy
+				fields["proxy_mime"] = proxyMime
+			}
+		}
+
+		if len(fields) == 0 {
+			continue
+		}
+		if err := UpdateImageMeta(row.Filename, fields); err != nil {
+			log.Printf("BackfillImages: update %s: %v", row.Filename, err)
+			continue
+		}
+		processed++
+	}
+	log.Printf("BackfillImages: finished, %d row(s) updated", processed)
+}
+
+var blobRefRegex = regexp.MustCompile(`/api/blob/([a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9]+)?)`)
+
+// BindOrphanBlobs finds blob references in the given content string and, for
+// any matching ImageData rows that are currently orphans (empty OwnerType) and
+// were uploaded by the same user, binds them to the given owner. Used by the
+// vulnerability create/update path so screenshots pasted during registration
+// get their ACL set when the vuln is saved.
+func BindOrphanBlobs(ownerType string, ownerID uint, uploaderEmail, content string) {
+	if ownerType == "" || ownerID == 0 || uploaderEmail == "" || content == "" {
+		return
+	}
+	matches := blobRefRegex.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return
+	}
+	filenames := make([]string, 0, len(matches))
+	seen := map[string]struct{}{}
+	for _, m := range matches {
+		f := m[1]
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		filenames = append(filenames, f)
+	}
+	err := db.Model(&ImageData{}).
+		Where("filename IN ? AND uploader_email = ? AND (owner_type = '' OR owner_type IS NULL)", filenames, uploaderEmail).
+		Updates(map[string]interface{}{
+			"owner_type": ownerType,
+			"owner_id":   ownerID,
+		}).Error
+	if err != nil {
+		log.Printf("BindOrphanBlobs: %v", err)
+	}
+}
+
+func findVulnReferencing(filename string) (*JSONData, bool) {
+	var jd JSONData
+	// Match the filename anywhere in the vulnerability JSON. Fast enough for
+	// a one-shot backfill; SQLite's LIKE is table-scan but we only run once.
+	err := db.Where("vulnerability LIKE ?", "%"+filename+"%").First(&jd).Error
+	if err != nil {
+		return nil, false
+	}
+	return &jd, true
+}
+
+func resizeLongEdge(src image.Image, maxEdge int) image.Image {
+	bounds := src.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	long := w
+	if h > long {
+		long = h
+	}
+	// Never upscale.
+	if long <= maxEdge {
+		return src
+	}
+	ratio := float64(maxEdge) / float64(long)
+	nw := int(float64(w) * ratio)
+	nh := int(float64(h) * ratio)
+	dst := image.NewRGBA(image.Rect(0, 0, nw, nh))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), src, bounds, draw.Over, nil)
+	return dst
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module prism
 go 1.26.0
 
 require (
+	github.com/HugoSmits86/nativewebp v1.3.0
 	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/gin-gonic/gin v1.12.0
@@ -12,6 +13,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2
 	github.com/pquerna/otp v1.5.0
 	github.com/slack-go/slack v0.23.1
+	golang.org/x/image v0.41.0
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/datatypes v1.2.7

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/HugoSmits86/nativewebp v1.3.0 h1:n1egtEzSV4KwFtealr7dzdYq1wI/uj/bOQ/QcTcIyVE=
+github.com/HugoSmits86/nativewebp v1.3.0/go.mod h1:YNQuWenlVmSUUASVNhTDwf4d7FwYQGbGhklC8p72Vr8=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -158,6 +160,8 @@ golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/api/main.go
+++ b/api/main.go
@@ -175,6 +175,7 @@ func main() {
 		apiRoutes.GET("/slack/channels", routes.GetSlackChannels)
 
 		apiRoutes.GET("/blob/:filename", routes.GetBlob)
+		apiRoutes.GET("/blob/:filename/original", routes.GetBlobOriginal)
 		apiRoutes.POST("/blob/upload", routes.HandleBlobUpload)
 		apiRoutes.DELETE("/blob/:filename", routes.HandleBlobDelete)
 
@@ -222,6 +223,10 @@ func main() {
 	}
 
 	go event.PollEventQueue()
+
+	// Backfill owner metadata and generate proxies for legacy image blobs.
+	// Runs once per startup in the background so boot isn't blocked.
+	go database.BackfillImages()
 
 	// Run the main application in a separate goroutine
 	go func() {

--- a/api/roles.yaml
+++ b/api/roles.yaml
@@ -65,6 +65,8 @@ roles:
         action: [""]
       - resource: "/profile"
         action: ["read"]
+      - resource: "/blob"
+        action: ["read"]
       - resource: "/notification"
         action: ["*"]
       - resource: "/notes"
@@ -85,6 +87,8 @@ roles:
       - resource: "/settings"
         action: [""]
       - resource: "/profile"
+        action: ["read"]
+      - resource: "/blob"
         action: ["read"]
       - resource: "/planning"
         action: ["*"]

--- a/api/routes/blob.go
+++ b/api/routes/blob.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -13,6 +13,16 @@ import (
 	"prism/config"
 	"prism/database"
 )
+
+// allowedImageMimes is the exhaustive set of MIME types accepted by the blob
+// upload endpoint. Anything else is rejected so the endpoint can't be used as
+// a same-origin HTML/SVG/JS host (pentest finding F-1/F-3).
+var allowedImageMimes = map[string]string{
+	"image/png":  ".png",
+	"image/jpeg": ".jpg",
+	"image/gif":  ".gif",
+	"image/webp": ".webp",
+}
 
 func GetBlob(c *gin.Context) {
 	filename := c.Param("filename")
@@ -29,23 +39,20 @@ func GetBlob(c *gin.Context) {
 		return
 	}
 
-	// Serve the proxy to non-creators, original to creators.
-	data := img.ProxyData
-	mime := img.ProxyMime
-	if len(data) == 0 {
-		// No proxy yet (pre-backfill row). Fall back to the original but only
-		// if the requester is the creator — otherwise refuse.
-		if !isBlobCreator(c, img) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		data = img.Data
-		mime = img.Mime
+	// Always serve the proxy. If none exists (legacy non-image row that
+	// couldn't be decoded during backfill), refuse — do NOT fall back to
+	// img.Data, which could be an arbitrary byte stream with an attacker-
+	// controlled MIME. Pentest finding F-1 was live XSS via this path.
+	if len(img.ProxyData) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
 	}
+	mime := img.ProxyMime
 	if mime == "" {
 		mime = "application/octet-stream"
 	}
-	c.Data(http.StatusOK, mime, data)
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Data(http.StatusOK, mime, img.ProxyData)
 }
 
 // GetBlobOriginal serves the untouched original. Only the creator of the
@@ -63,9 +70,13 @@ func GetBlobOriginal(c *gin.Context) {
 		return
 	}
 	mime := img.Mime
-	if mime == "" {
+	if _, ok := allowedImageMimes[mime]; !ok {
+		// Defence-in-depth: a legacy row could have a MIME we no longer
+		// trust to render inline. Force download in that case.
 		mime = "application/octet-stream"
 	}
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	c.Data(http.StatusOK, mime, img.Data)
 }
 
@@ -81,18 +92,7 @@ func canReadBlob(c *gin.Context, img *database.ImageData) bool {
 
 	switch img.OwnerType {
 	case "vulnerability":
-		// "Global viewer" = role has a broad /vulnerability/:id permission
-		// entry, mirroring the logic in auth.ACLMiddleware.
-		globalViewer := false
-		if r, ok := config.AppConfig.Roles[roleStr]; ok {
-			for _, p := range r.Permissions {
-				if p.Resource == "/vulnerability/:id" {
-					globalViewer = true
-					break
-				}
-			}
-		}
-		ok, err := database.CanAccessVulnerability(img.OwnerID, emailStr, roleStr, globalViewer)
+		ok, err := database.CanAccessVulnerability(img.OwnerID, emailStr, roleStr, roleHasGlobalVulnerability(roleStr))
 		if err != nil {
 			log.Printf("canReadBlob: CanAccessVulnerability: %v", err)
 			return false
@@ -100,7 +100,7 @@ func canReadBlob(c *gin.Context, img *database.ImageData) bool {
 		return ok
 	default:
 		// Orphan blobs (not yet bound to a vulnerability by the POST/PUT
-		// handler) — only the uploader or admin can see.
+		// handler) — only the uploader can see.
 		return emailStr != "" && img.UploaderEmail == emailStr
 	}
 }
@@ -125,6 +125,22 @@ func isBlobCreator(c *gin.Context, img *database.ImageData) bool {
 	return emailStr != "" && img.UploaderEmail == emailStr
 }
 
+// roleHasGlobalVulnerability mirrors auth.ACLMiddleware's check: if a role
+// declares /vulnerability/:id in its permissions, it gets the "global viewer"
+// flag for vulnerability ACL evaluation.
+func roleHasGlobalVulnerability(roleStr string) bool {
+	r, ok := config.AppConfig.Roles[roleStr]
+	if !ok {
+		return false
+	}
+	for _, p := range r.Permissions {
+		if p.Resource == "/vulnerability/:id" {
+			return true
+		}
+	}
+	return false
+}
+
 func HandleBlobUpload(c *gin.Context) {
 	form, err := c.MultipartForm()
 	if err != nil {
@@ -134,28 +150,49 @@ func HandleBlobUpload(c *gin.Context) {
 
 	email, _ := c.Get("email")
 	uploader, _ := email.(string)
+	role, _ := c.Get("role")
+	roleStr, _ := role.(string)
 
+	// context= binds the upload to a specific resource so the read-side ACL
+	// can be derived from the parent resource. Currently only "vulnerability"
+	// is supported; anything else falls through to orphan (uploader-only).
 	ownerType := c.PostForm("context")
 	ownerIDStr := c.PostForm("id")
 	var ownerID uint
-	if ownerIDStr != "" {
-		if v, err := strconv.ParseUint(ownerIDStr, 10, 64); err == nil {
-			ownerID = uint(v)
+	if ownerType == "vulnerability" {
+		if ownerIDStr == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "id is required when context=vulnerability"})
+			return
 		}
-	}
-	// Only "vulnerability" is a supported context today; anything else becomes
-	// an orphan (uploader-only) until the vulnerability create/update handler
-	// claims it via BindOrphanBlobs.
-	if ownerType != "vulnerability" {
+		v, err := strconv.ParseUint(ownerIDStr, 10, 64)
+		if err != nil || v == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+			return
+		}
+		ownerID = uint(v)
+		// Pentest finding F-2: the uploader must actually have access to the
+		// vulnerability they're claiming to attach the blob to. Without this
+		// check, any /blob:write role can plant bytes in any vulnerability's
+		// namespace — and the vulnerability creator would download them via
+		// /original believing they were pristine.
+		canAccess, err := database.CanAccessVulnerability(ownerID, uploader, roleStr, roleHasGlobalVulnerability(roleStr))
+		if err != nil || !canAccess {
+			c.JSON(http.StatusForbidden, gin.H{"error": "not allowed to attach to this resource"})
+			return
+		}
+	} else {
 		ownerType = ""
 		ownerID = 0
 	}
 
 	files := form.File["image"]
+	if len(files) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no image file in request"})
+		return
+	}
+
 	var filenames []string
 	for _, file := range files {
-		filename := generateUniqueFilename(file.Filename)
-
 		fileData, err := file.Open()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -168,15 +205,25 @@ func HandleBlobUpload(c *gin.Context) {
 			return
 		}
 
+		// Pentest finding F-1/F-3: reject anything that isn't a known image
+		// MIME (sniffed from the bytes, not the attacker-controlled multipart
+		// header). The extension is derived from the sniffed MIME so the
+		// stored filename can't carry a surprise extension like .html.
 		mime := database.DetectMime(data)
-		proxyBytes, proxyMime, perr := database.GenerateProxy(data, mime)
-		if perr != nil {
-			// Non-image or unsupported format — skip proxy, but still store
-			// so existing flows (e.g. non-image attachments) don't break.
-			proxyBytes = nil
-			proxyMime = ""
+		ext, ok := allowedImageMimes[mime]
+		if !ok {
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "unsupported image type"})
+			return
 		}
 
+		proxyBytes, proxyMime, perr := database.GenerateProxy(data, mime)
+		if perr != nil {
+			// The MIME said image but the decoder disagreed. Refuse.
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "image could not be decoded"})
+			return
+		}
+
+		filename := uuid.New().String() + ext
 		img := &database.ImageData{
 			Filename:      filename,
 			Data:          data,
@@ -200,15 +247,15 @@ func HandleBlobUpload(c *gin.Context) {
 
 func HandleBlobDelete(c *gin.Context) {
 	filename := c.Param("filename")
+	// Guard against path-traversal in the filename param (Gin's :filename
+	// already limits the match but belt-and-suspenders).
+	if strings.ContainsAny(filename, "/\\") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid filename"})
+		return
+	}
 	if err := database.DeleteImage(filename); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "File deleted successfully"})
-}
-
-func generateUniqueFilename(originalName string) string {
-	newUUID := uuid.New()
-	extension := filepath.Ext(originalName)
-	return newUUID.String() + extension
 }

--- a/api/routes/blob.go
+++ b/api/routes/blob.go
@@ -2,25 +2,127 @@ package routes
 
 import (
 	"io"
+	"log"
 	"net/http"
 	"path/filepath"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"prism/config"
 	"prism/database"
 )
 
 func GetBlob(c *gin.Context) {
 	filename := c.Param("filename")
 
-	imgData, err := database.GetImage(filename)
+	img, err := database.GetImage(filename)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error retrieving file"})
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return
 	}
 
-	c.Data(http.StatusOK, "image/jpeg", imgData.Data)
+	if !canReadBlob(c, img) {
+		// Don't leak the distinction between "doesn't exist" and "no access".
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+
+	// Serve the proxy to non-creators, original to creators.
+	data := img.ProxyData
+	mime := img.ProxyMime
+	if len(data) == 0 {
+		// No proxy yet (pre-backfill row). Fall back to the original but only
+		// if the requester is the creator — otherwise refuse.
+		if !isBlobCreator(c, img) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		data = img.Data
+		mime = img.Mime
+	}
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	c.Data(http.StatusOK, mime, data)
+}
+
+// GetBlobOriginal serves the untouched original. Only the creator of the
+// resource the blob was uploaded for may access it.
+func GetBlobOriginal(c *gin.Context) {
+	filename := c.Param("filename")
+
+	img, err := database.GetImage(filename)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	if !isBlobCreator(c, img) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	mime := img.Mime
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	c.Data(http.StatusOK, mime, img.Data)
+}
+
+// canReadBlob returns true if the user can see at least the proxy.
+func canReadBlob(c *gin.Context, img *database.ImageData) bool {
+	email, _ := c.Get("email")
+	role, _ := c.Get("role")
+	emailStr, _ := email.(string)
+	roleStr, _ := role.(string)
+	if roleStr == "admin" {
+		return true
+	}
+
+	switch img.OwnerType {
+	case "vulnerability":
+		// "Global viewer" = role has a broad /vulnerability/:id permission
+		// entry, mirroring the logic in auth.ACLMiddleware.
+		globalViewer := false
+		if r, ok := config.AppConfig.Roles[roleStr]; ok {
+			for _, p := range r.Permissions {
+				if p.Resource == "/vulnerability/:id" {
+					globalViewer = true
+					break
+				}
+			}
+		}
+		ok, err := database.CanAccessVulnerability(img.OwnerID, emailStr, roleStr, globalViewer)
+		if err != nil {
+			log.Printf("canReadBlob: CanAccessVulnerability: %v", err)
+			return false
+		}
+		return ok
+	default:
+		// Orphan blobs (not yet bound to a vulnerability by the POST/PUT
+		// handler) — only the uploader or admin can see.
+		return emailStr != "" && img.UploaderEmail == emailStr
+	}
+}
+
+// isBlobCreator returns true if the user is the creator of the resource the
+// blob is attached to — vulnerability FoundBy, or uploader for orphans.
+func isBlobCreator(c *gin.Context, img *database.ImageData) bool {
+	email, _ := c.Get("email")
+	role, _ := c.Get("role")
+	emailStr, _ := email.(string)
+	roleStr, _ := role.(string)
+	if roleStr == "admin" {
+		return true
+	}
+	if img.OwnerType == "vulnerability" {
+		vuln, err := database.GetJSONData(img.OwnerID)
+		if err != nil {
+			return false
+		}
+		return vuln.FoundBy == emailStr
+	}
+	return emailStr != "" && img.UploaderEmail == emailStr
 }
 
 func HandleBlobUpload(c *gin.Context) {
@@ -30,27 +132,62 @@ func HandleBlobUpload(c *gin.Context) {
 		return
 	}
 
+	email, _ := c.Get("email")
+	uploader, _ := email.(string)
+
+	ownerType := c.PostForm("context")
+	ownerIDStr := c.PostForm("id")
+	var ownerID uint
+	if ownerIDStr != "" {
+		if v, err := strconv.ParseUint(ownerIDStr, 10, 64); err == nil {
+			ownerID = uint(v)
+		}
+	}
+	// Only "vulnerability" is a supported context today; anything else becomes
+	// an orphan (uploader-only) until the vulnerability create/update handler
+	// claims it via BindOrphanBlobs.
+	if ownerType != "vulnerability" {
+		ownerType = ""
+		ownerID = 0
+	}
+
 	files := form.File["image"]
 	var filenames []string
 	for _, file := range files {
 		filename := generateUniqueFilename(file.Filename)
 
-		// Read file data
 		fileData, err := file.Open()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		defer fileData.Close()
-
 		data, err := io.ReadAll(fileData)
+		fileData.Close()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
 
-		// Save the file data to the database
-		if err := database.SaveImage(filename, data); err != nil {
+		mime := database.DetectMime(data)
+		proxyBytes, proxyMime, perr := database.GenerateProxy(data, mime)
+		if perr != nil {
+			// Non-image or unsupported format — skip proxy, but still store
+			// so existing flows (e.g. non-image attachments) don't break.
+			proxyBytes = nil
+			proxyMime = ""
+		}
+
+		img := &database.ImageData{
+			Filename:      filename,
+			Data:          data,
+			Mime:          mime,
+			ProxyData:     proxyBytes,
+			ProxyMime:     proxyMime,
+			UploaderEmail: uploader,
+			OwnerType:     ownerType,
+			OwnerID:       ownerID,
+		}
+		if err := database.SaveImageFull(img); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -62,15 +199,11 @@ func HandleBlobUpload(c *gin.Context) {
 }
 
 func HandleBlobDelete(c *gin.Context) {
-	filename := c.Param("filename") // Get the filename from the URL parameter
-
-	// Attempt to delete the image record from the database
-	err := database.DeleteImage(filename)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error deleting file"})
+	filename := c.Param("filename")
+	if err := database.DeleteImage(filename); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 		return
 	}
-
 	c.JSON(http.StatusOK, gin.H{"message": "File deleted successfully"})
 }
 

--- a/api/routes/vulnerability.go
+++ b/api/routes/vulnerability.go
@@ -425,6 +425,10 @@ func PutVulnerability(c *gin.Context) {
 		return
 	}
 
+	email, _ := c.Get("email")
+	emailStr, _ := email.(string)
+	database.BindOrphanBlobs("vulnerability", jsonData.ID, emailStr, string(jsonData.Vulnerability))
+
 	c.JSON(http.StatusOK, gin.H{})
 }
 
@@ -481,6 +485,9 @@ func PostVulnerability(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+
+	// Claim any orphan blobs the uploader pasted during registration.
+	database.BindOrphanBlobs("vulnerability", jsonData.ID, jsonData.FoundBy, string(jsonData.Vulnerability))
 
 	c.JSON(http.StatusCreated, gin.H{"id": jsonData.ID})
 }

--- a/api/routes/vulnerability.go
+++ b/api/routes/vulnerability.go
@@ -367,6 +367,12 @@ func PatchVulnerability(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
+		// Claim any of the uploader's orphan blobs referenced in the merged
+		// content so they get the vulnerability's ACL (mirrors POST/PUT).
+		email, _ := c.Get("email")
+		if s, ok := email.(string); ok {
+			database.BindOrphanBlobs("vulnerability", id, s, string(mergedBytes))
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"data": json.RawMessage(mergedBytes)})

--- a/web/src/routes/(app)/notes/+page.svelte
+++ b/web/src/routes/(app)/notes/+page.svelte
@@ -19,8 +19,6 @@
     remoteUpdatedConflict,
   } from '$lib/stores/notesStore';
   import { Fetch } from '$lib/fetchUtil';
-  import { apiEndpoint } from '$lib/stores/configStore';
-  import { get } from 'svelte/store';
 
   const pretitle = 'Personal';
   const title = 'Notes';
@@ -73,39 +71,87 @@
   async function handleImagePaste(event) {
     const blob = event.detail?.blob;
     if (!blob) return;
-    await uploadAndInsert(blob, null);
+    await downscaleAndInline(blob, null);
   }
 
   async function handleImageDrop(event) {
     const { files, pos } = event.detail || {};
     if (!files?.length) return;
     for (const file of files) {
-      await uploadAndInsert(file, pos);
+      await downscaleAndInline(file, pos);
     }
   }
 
-  async function uploadAndInsert(file, pos) {
-    const form = new FormData();
-    // Backend (api/routes/blob.go) reads the multipart form field "image".
-    form.append('image', file);
-    const endpoint = get(apiEndpoint);
-    const res = await fetch(`${endpoint}/api/blob/upload`, {
-      method: 'POST',
-      body: form,
-      credentials: 'include',
-    });
-    if (!res.ok) return;
-    const data = await res.json();
-    const filename = Array.isArray(data?.fileNames) ? data.fileNames[0] : null;
-    if (!filename) return;
-    const alt = file.name || 'image';
-    const link = `![${alt}](/api/blob/${filename})`;
+  // Notes embed images as inline data: URIs so each image is structurally
+  // tied 1:1 to the note it lives in — no external blob endpoint, no
+  // orphanable rows, no ACL drift. Images are downscaled to 1080px on the
+  // long edge and encoded as WebP (JPEG fallback) to keep the autosave
+  // payload bounded.
+  async function downscaleAndInline(file, pos) {
+    if (!$selectedNoteId) return;
+    let dataUri;
+    try {
+      dataUri = await resizeToDataUri(file, 1080);
+    } catch (err) {
+      console.error('Failed to process image:', err);
+      return;
+    }
+    if (!dataUri) return;
+    const alt = (file.name || 'image').replace(/[\[\]]/g, '');
+    const link = `![${alt}](${dataUri})`;
     await tick();
     if (pos != null && editorRef?.insertImageAtPosition) {
       editorRef.insertImageAtPosition(link, pos);
     } else if (editorRef?.insertImageAtCursor) {
       editorRef.insertImageAtCursor(link);
     }
+  }
+
+  function resizeToDataUri(file, maxEdge) {
+    return new Promise((resolve, reject) => {
+      const url = URL.createObjectURL(file);
+      const img = new Image();
+      img.onload = () => {
+        try {
+          const long = Math.max(img.naturalWidth, img.naturalHeight);
+          const ratio = long > maxEdge ? maxEdge / long : 1;
+          const w = Math.max(1, Math.round(img.naturalWidth * ratio));
+          const h = Math.max(1, Math.round(img.naturalHeight * ratio));
+          const canvas = document.createElement('canvas');
+          canvas.width = w;
+          canvas.height = h;
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0, w, h);
+          // Try WebP first; fall back to JPEG if the browser doesn't
+          // support toBlob('image/webp').
+          canvas.toBlob((blob) => {
+            URL.revokeObjectURL(url);
+            if (blob) { readAsDataUrl(blob).then(resolve, reject); return; }
+            canvas.toBlob((jpegBlob) => {
+              if (!jpegBlob) { reject(new Error('canvas.toBlob returned null')); return; }
+              readAsDataUrl(jpegBlob).then(resolve, reject);
+            }, 'image/jpeg', 0.85);
+          }, 'image/webp', 0.85);
+        } catch (err) {
+          URL.revokeObjectURL(url);
+          reject(err);
+        }
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        reject(new Error('Failed to decode image'));
+      };
+      img.src = url;
+    });
+  }
+
+  function readAsDataUrl(blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('FileReader failed'));
+      reader.readAsDataURL(blob);
+    });
   }
 
   async function reloadCurrentNote() {


### PR DESCRIPTION
## Summary

Replaces \"unguessable URL\" as the only barrier for image blobs with a real per-vulnerability ACL, generates a downscaled WebP proxy alongside the original, and closes findings **F-1..F-7** from the 2026-04-20 pentest. Notes editor stops uploading at all — images are inlined as data: URIs client-side.

## Commits

| Commit | Scope |
|---|---|
| `56fe3bd` | feat: proxy-first blob serving with per-vulnerability ACL |
| `876d92e` | feat: inline base64 images in notes, client-side downscaled |
| `2e91b1a` | fix(blob): close findings F-1..F-7 from the 2026-04-20 pentest |
| `6bc0fa2` | chore(api): go mod tidy after Svelte5 rebase |

## Pentest findings closed

- **F-1** XSS via legacy non-image blob fallback — \`GetBlob\` no longer serves \`img.Data\` when \`ProxyData\` is empty; legacy non-image rows now 404.
- **F-2, F-7** Cross-vulnerability blob planting — upload with \`context=vulnerability\` now requires a parseable non-zero id AND \`CanAccessVulnerability\`.
- **F-1, F-3** Filename/MIME smuggling — only accept image/{png,jpeg,gif,webp} by sniffed MIME (not the multipart header). Extension derives from the sniffed MIME.
- **F-4** Content-type sniffing — \`X-Content-Type-Options: nosniff\` on both blob endpoints; \`/original\` emits \`Content-Disposition: attachment\` and downgrades any non-allowed legacy MIME to \`application/octet-stream\`.

## Design notes

- 1080px WebP proxy generated via \`golang.org/x/image/draw\` + \`github.com/HugoSmits86/nativewebp\` (pure Go, no CGO image pipeline).
- \`GET /api/blob/:filename\` → proxy, gated by vulnerability read access.
- \`GET /api/blob/:filename/original\` → pristine bytes, restricted to the vulnerability's \`FoundBy\` so only the original uploader can re-annotate/crop without quality loss.
- Orphan blobs (pasted during vulnerability registration before the record exists) are uploader-scoped until \`PostVulnerability\` claims them.
- Roles: \`/blob: [read]\` added to \`global_viewer\` and \`manager\` (they already read vulnerabilities).
- Notes editor (\`/notes\`): pastes/drops decode in the browser, downscale to 1080px on the long edge, re-encode WebP (JPEG fallback), embed as \`data:\` URIs. No \`/api/blob/upload\` hit at all.

## Test plan

- [ ] CI build passes.
- [ ] **F-1, F-3**: upload a \`.html\` renamed \`.png\` → 415; stored row's filename does not end \`.html\`/\`.exe\`.
- [ ] **F-2, F-7**: user A creates V1; user B (no access) tries \`POST /api/blob/upload?context=vulnerability&vulnerability_id=V1\` → 403/404.
- [ ] **F-1**: legacy non-image blob row → \`GET /api/blob/<id>\` returns 404, not raw bytes.
- [ ] **F-4**: \`curl -I /api/blob/<id>\` has \`X-Content-Type-Options: nosniff\`; \`/original\` has \`Content-Disposition: attachment\`.
- [ ] Per-vulnerability ACL: B can't fetch A's blob; only A (FoundBy) can fetch \`/original\`.
- [ ] Notes paste a 4k screenshot → no \`/api/blob/upload\` request; image inlined as \`data:image/webp;base64,...\`; long edge ≤ 1080px; survives reload.