### PR TITLE
feat(notifications): rebuild push + in-app for cross-user safety

### DIFF
--- a/api/database/db.go
+++ b/api/database/db.go
@@ -37,10 +37,42 @@ type ProjectData struct {
 	IsBugBounty  bool
 }
 
+// Subscriber is one push subscription tied to one browser/device. Endpoint is
+// globally unique — the same physical browser can only belong to one user at a
+// time. When a different user enables push on the same browser, the upsert in
+// subscribers.go takes the row over (rebinds Email + keys). This is what stops
+// cross-user push delivery on shared browsers.
+//
+// The legacy `subscription` JSON column from earlier schema versions is left in
+// place by GORM (auto-migrate never drops columns); the migration in
+// notification_migrate.go reads it to backfill the typed columns on first run
+// and ignores it thereafter.
 type Subscriber struct {
 	gorm.Model
-	Email        string
-	Subscription datatypes.JSON
+	Email      string    `gorm:"index"`
+	Endpoint   string    `gorm:"index"`
+	P256dh     string    `json:"-"`
+	Auth       string    `json:"-"`
+	UserAgent  string    `json:"-"`
+	LastSeenAt time.Time `json:"lastSeenAt"`
+}
+
+// Notification is an in-app notification row. Replaces the old per-user JSON
+// blob on UserData.Notifications that suffered read-modify-write races under
+// concurrent dispatch.
+type Notification struct {
+	ID              uint   `gorm:"primaryKey" json:"id"`
+	RecipientEmail  string `gorm:"index:idx_notif_recipient_created;index:idx_notif_recipient_read" json:"-"`
+	Kind            string `json:"kind,omitempty"`
+	Who             string `json:"who"`
+	What            string `json:"what"`
+	Where           string `json:"where"`
+	VulnerabilityID *uint  `json:"vulnerabilityId,omitempty"`
+	// IsRead defaults false. A scoped UPDATE flips it without ever rewriting
+	// the rest of the row, so two concurrent dispatchers can never clobber
+	// each other's writes.
+	IsRead    bool      `gorm:"index:idx_notif_recipient_read;default:false" json:"read"`
+	CreatedAt time.Time `gorm:"index:idx_notif_recipient_created" json:"when"`
 }
 
 func CreateProject(project *ProjectData) error {
@@ -151,15 +183,17 @@ type Metrics struct {
 
 type UserData struct {
 	gorm.Model
-	Email         string         `json:"email" gorm:"uniqueIndex"`
-	Name          string         `json:"name"`
-	Picture       string         `json:"picture"`
-	Role          string         `json:"role" gorm:"default:visitor"`
-	Title         string         `json:"title" gorm:"default:My title"`
-	Active        *bool          `json:"active" gorm:"default:true"`
-	OTPSecret     string         `json:"-"`
-	Notifications datatypes.JSON `json:"-"`
-	Settings      datatypes.JSON `json:"-"`
+	Email     string `json:"email" gorm:"uniqueIndex"`
+	Name      string `json:"name"`
+	Picture   string `json:"picture"`
+	Role      string `json:"role" gorm:"default:visitor"`
+	Title     string `json:"title" gorm:"default:My title"`
+	Active    *bool  `json:"active" gorm:"default:true"`
+	OTPSecret string `json:"-"`
+	// Notifications used to be a datatypes.JSON column on this row; the legacy
+	// column is left in place by GORM (auto-migrate never drops columns) and
+	// drained into the dedicated notifications table by notification_migrate.go.
+	Settings datatypes.JSON `json:"-"`
 }
 
 type Vulnerability struct {
@@ -254,6 +288,7 @@ func InitDB() {
 	db.AutoMigrate(&VulnerabilityAttachment{})
 	db.AutoMigrate(&AssessmentJSON{})
 	db.AutoMigrate(&Subscriber{})
+	db.AutoMigrate(&Notification{})
 	db.AutoMigrate(&models.APIKey{})
 	db.AutoMigrate(&models.SharedDocument{})
 	db.AutoMigrate(&models.Team{})
@@ -454,29 +489,9 @@ func GetAllProfilesWithTeams() (*ProfileResponse, error) {
 	}, nil
 }
 
-func DeleteNotifications(email string) error {
-	var userData UserData
-
-	// Fetch the user data by email
-	result := db.Where("email = ?", email).First(&userData)
-	if result.Error != nil {
-		return result.Error
-	}
-
-	userData.Notifications = nil
-
-	result = db.Save(&userData)
-	return result.Error
-}
-
-func GetAllSubscribers() ([]Subscriber, error) {
-	var subscriberList []Subscriber
-	result := db.Find(&subscriberList)
-	if result.Error != nil {
-		return nil, result.Error
-	}
-	return subscriberList, nil
-}
+// DeleteNotifications / GetNotifications / CreateNotification / MarkNotificationAsRead
+// were rewritten against the new notifications table in notifications.go. The
+// subscriber CRUD lives in subscribers.go.
 
 func ExistsShare(token string) (*models.SharedDocument, error) {
 	var share models.SharedDocument
@@ -531,121 +546,8 @@ func PersistShareDocument(share *models.SharedDocument) error {
 	return nil
 }
 
-func AppendSubscriber(email string, subs []byte) error {
-	subscriber := Subscriber{
-		Email:        email,
-		Subscription: subs,
-	}
-
-	if err := db.Create(&subscriber).Error; err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func CreateNotification(email string, notification models.Notification) error {
-	var userData UserData
-
-	// Fetch the user data by email
-	result := db.Where("email = ?", email).First(&userData)
-	if result.Error != nil {
-		// Check if the error is a RecordNotFound error
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			// Fail softly by returning nil
-			return nil
-		}
-		// For other types of errors, return the error
-		return result.Error
-	}
-
-	// Unmarshal the JSON notifications into a slice
-	var notifications []models.Notification
-	// Check if the JSON field has content before unmarshalling
-	if len(userData.Notifications) > 0 {
-		if err := json.Unmarshal(userData.Notifications, &notifications); err != nil {
-			return err
-		}
-	} else {
-		// If the JSON is nil or empty, initialize it to an empty slice to avoid null in JSON output
-		notifications = []models.Notification{}
-	}
-
-	notifications = append(notifications, notification)
-
-	// Marshal the updated notifications slice back into JSON
-	updatedNotifications, err := json.Marshal(notifications)
-	if err != nil {
-		return err
-	}
-	userData.Notifications = updatedNotifications
-
-	// Save the updated user data back to the database
-	result = db.Save(&userData)
-	return result.Error
-}
-
-func MarkNotificationAsRead(email string, notificationTime time.Time) error {
-	var userData UserData
-
-	// Fetch the user data by email
-	result := db.Where("email = ?", email).First(&userData)
-	if result.Error != nil {
-		return result.Error
-	}
-
-	// Unmarshal the JSON notifications into a slice
-	var notifications []models.Notification
-	if err := json.Unmarshal(userData.Notifications, &notifications); err != nil {
-		return err
-	}
-
-	// Mark the notification as read
-	updated := false
-	for i, notification := range notifications {
-		if notification.When.Equal(notificationTime) && !notification.IsRead {
-			notifications[i].IsRead = true
-			updated = true
-			break
-		}
-	}
-
-	// If the notification was found and updated, marshal the slice back to JSON and update the record
-	if updated {
-		updatedNotifications, err := json.Marshal(notifications)
-		if err != nil {
-			return err
-		}
-		userData.Notifications = updatedNotifications
-		result = db.Save(&userData)
-		return result.Error
-	}
-
-	// If no updates were made, return nil to indicate no error occurred
-	return nil
-}
-
-func GetNotifications(email string) ([]models.Notification, error) {
-	var userData UserData
-	result := db.Where("email = ?", email).First(&userData)
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	var notifications []models.Notification
-
-	// Check if the JSON field has content before unmarshalling
-	if len(userData.Notifications) > 0 {
-		if err := json.Unmarshal(userData.Notifications, &notifications); err != nil {
-			return nil, err
-		}
-	} else {
-		// If the JSON is nil or empty, initialize it to an empty slice to avoid null in JSON output
-		notifications = []models.Notification{}
-	}
-
-	return notifications, nil
-}
+// Notification + subscriber CRUD now live in notifications.go and
+// subscribers.go.
 
 func UpdateAssassment(assessment models.Assessment, id uint) error {
 	data, err := json.Marshal(assessment)
@@ -959,6 +861,36 @@ func CanAccessVulnerability(vulnID uint, email string, role string, globalViewer
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// CanRecipientSeeVulnerability is the access check used by the notification
+// dispatcher. It refuses delivery to deactivated users and to anyone whose
+// current role no longer covers the vulnerability — so a hacker removed from
+// a project after commenting stops receiving notifications about it.
+func CanRecipientSeeVulnerability(email string, vulnID uint) (bool, error) {
+	var u UserData
+	if err := db.Select("role, active").Where("email = ?", email).First(&u).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if u.Active != nil && !*u.Active {
+		return false, nil
+	}
+	role := u.Role
+	roleCfg, ok := config.AppConfig.Roles[role]
+	if !ok {
+		return false, nil
+	}
+	globalViewer := false
+	for _, perm := range roleCfg.Permissions {
+		if perm.Resource == "/vulnerability/:id" {
+			globalViewer = true
+			break
+		}
+	}
+	return CanAccessVulnerability(vulnID, email, role, globalViewer)
 }
 
 func HasAccessToProject(email string, projectID string, role string) (bool, error) {

--- a/api/database/notification_migrate.go
+++ b/api/database/notification_migrate.go
@@ -1,0 +1,147 @@
+package database
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// NotificationMigrationReport summarises one pass of MigrateNotifications so
+// startup logs make the migration's effect visible without re-querying.
+type NotificationMigrationReport struct {
+	SubscribersCleared    int
+	UniqueIndexInstalled  bool
+	UserRowsWithLegacy    int
+	JSONColumnCleared     int
+	Errors                []string
+}
+
+func (r NotificationMigrationReport) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "subscribers cleared       : %d\n", r.SubscribersCleared)
+	fmt.Fprintf(&b, "unique index installed    : %t\n", r.UniqueIndexInstalled)
+	fmt.Fprintf(&b, "users with legacy blobs   : %d\n", r.UserRowsWithLegacy)
+	fmt.Fprintf(&b, "json columns cleared      : %d\n", r.JSONColumnCleared)
+	if len(r.Errors) > 0 {
+		fmt.Fprintf(&b, "errors (%d):\n", len(r.Errors))
+		for _, e := range r.Errors {
+			fmt.Fprintf(&b, "  - %s\n", e)
+		}
+	}
+	return b.String()
+}
+
+// MigrateNotifications upgrades the notification system without carrying the
+// pre-refactor corrupted state forward. The cross-user delivery bug lived in
+// the existing subscribers + user_data.notifications data; preserving any of
+// it would re-import the bug. So this migration is "wipe and rebuild":
+//
+//  1. DELETE every row from subscribers. Users will re-subscribe through the
+//     new POST /api/notification/subscribe, which goes via UpsertSubscriber
+//     and produces correctly endpoint-keyed rows.
+//  2. Install the UNIQUE index on endpoint, which the new upsert relies on.
+//  3. NULL user_data.notifications. Drops the legacy in-app dropdown history.
+//     New events repopulate the dedicated notifications table cleanly.
+//
+// Idempotent: a steady-state second run finds nothing to clear, no index to
+// install, and exits with an empty report.
+func MigrateNotifications() (NotificationMigrationReport, error) {
+	var report NotificationMigrationReport
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := wipeSubscribers(tx, &report); err != nil {
+			return fmt.Errorf("wipe subscribers: %w", err)
+		}
+		if err := installSubscriberUniqueIndex(tx, &report); err != nil {
+			return fmt.Errorf("install unique index: %w", err)
+		}
+		if err := clearUserNotificationsJSON(tx, &report); err != nil {
+			return fmt.Errorf("clear legacy notifications: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// wipeSubscribers removes any row in subscribers that still has the legacy
+// shape (no endpoint column populated). The first run clears everything;
+// subsequent runs see endpoint-populated rows from UpsertSubscriber and skip
+// them, so this is safe to re-execute on every boot.
+func wipeSubscribers(tx *gorm.DB, report *NotificationMigrationReport) error {
+	// Targeted hard delete: only rows that look pre-refactor (empty endpoint).
+	// New rows always have an endpoint, so they're untouched.
+	res := tx.Unscoped().
+		Where("endpoint IS NULL OR endpoint = ''").
+		Delete(&Subscriber{})
+	if res.Error != nil {
+		return res.Error
+	}
+	report.SubscribersCleared = int(res.RowsAffected)
+	return nil
+}
+
+// installSubscriberUniqueIndex adds the UNIQUE index on endpoint that
+// UpsertSubscriber's take-over semantics rely on. IF NOT EXISTS keeps a
+// re-run a no-op. Without this index, two concurrent subscribes could race
+// into two rows for the same endpoint, re-introducing the cross-user
+// delivery bug.
+func installSubscriberUniqueIndex(tx *gorm.DB, report *NotificationMigrationReport) error {
+	if err := tx.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_subscribers_endpoint_unique
+		ON subscribers(endpoint)
+		WHERE endpoint <> '' AND deleted_at IS NULL
+	`).Error; err != nil {
+		return err
+	}
+	report.UniqueIndexInstalled = true
+	return nil
+}
+
+// clearUserNotificationsJSON nulls out the legacy per-user notifications
+// blob. We intentionally do not drain into the new table: the old data is
+// what the original bug was misdelivering, and importing it would re-import
+// the misdelivery. The auto-migrate doesn't drop columns, so the column
+// itself stays; only its contents are cleared.
+func clearUserNotificationsJSON(tx *gorm.DB, report *NotificationMigrationReport) error {
+	// Probe via a cheap COUNT first; if the legacy column has already been
+	// dropped on some future schema generation we exit silently.
+	var count int64
+	err := tx.Raw(`
+		SELECT COUNT(*) FROM user_data
+		WHERE notifications IS NOT NULL AND length(notifications) > 0
+	`).Scan(&count).Error
+	if err != nil {
+		if strings.Contains(err.Error(), "no such column") {
+			return nil
+		}
+		return err
+	}
+	report.UserRowsWithLegacy = int(count)
+	if count == 0 {
+		return nil
+	}
+	res := tx.Exec(`UPDATE user_data SET notifications = NULL WHERE notifications IS NOT NULL`)
+	if res.Error != nil {
+		return res.Error
+	}
+	report.JSONColumnCleared = int(res.RowsAffected)
+	return nil
+}
+
+// RunNotificationMigrationOnce is invoked from main at startup. It logs the
+// report only when something actually happened so a steady-state boot stays
+// quiet.
+func RunNotificationMigrationOnce() {
+	report, err := MigrateNotifications()
+	if err != nil {
+		log.Printf("notification migration: %v", err)
+		return
+	}
+	if report.SubscribersCleared > 0 || report.JSONColumnCleared > 0 {
+		log.Printf("notification migration:\n%s", report.String())
+	}
+}

--- a/api/database/notification_migrate_test.go
+++ b/api/database/notification_migrate_test.go
@@ -1,0 +1,116 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SherClockHolmes/webpush-go"
+)
+
+func TestMigrateNotifications_Idempotent(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	// The setup helper already ran the migration once. A second run on a
+	// clean steady-state schema must succeed with an effectively empty
+	// report.
+	report, err := MigrateNotifications()
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if report.SubscribersCleared != 0 || report.JSONColumnCleared != 0 {
+		t.Fatalf("idempotent run should clear nothing, got %+v", report)
+	}
+	if !report.UniqueIndexInstalled {
+		t.Fatalf("unique index should still report installed on idempotent run")
+	}
+}
+
+// TestMigrateNotifications_WipesPreRefactorSubscribers verifies the
+// "wipe the bad state" behaviour the user asked for: rows that pre-date the
+// typed-endpoint schema (endpoint column NULL or empty) get hard-deleted on
+// migration, so the new endpoint-keyed upsert path starts from a clean slate.
+func TestMigrateNotifications_WipesPreRefactorSubscribers(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	// Insert a row that looks pre-refactor: no endpoint. The migration
+	// previously installed the unique index, so we add this row by going
+	// around the normal upsert path.
+	preRefactor := Subscriber{
+		Email:      "legacy@x",
+		Endpoint:   "",
+		LastSeenAt: time.Now(),
+	}
+	if err := db.Create(&preRefactor).Error; err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	// And a properly-shaped post-refactor row.
+	if err := UpsertSubscriber("modern@x", webpush.Subscription{
+		Endpoint: "https://push/modern",
+		Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+	}, "ua"); err != nil {
+		t.Fatalf("modern upsert: %v", err)
+	}
+
+	report, err := MigrateNotifications()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if report.SubscribersCleared != 1 {
+		t.Fatalf("expected 1 legacy row cleared, got %d (report: %+v)", report.SubscribersCleared, report)
+	}
+
+	// Legacy row gone, modern row preserved.
+	var rows []Subscriber
+	if err := db.Find(&rows).Error; err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly 1 surviving row, got %d", len(rows))
+	}
+	if rows[0].Email != "modern@x" {
+		t.Fatalf("wrong row survived: %+v", rows[0])
+	}
+}
+
+func TestMigrateNotifications_DoesNotImportLegacyInAppHistory(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	// AutoMigrate of UserData (post-refactor) doesn't include the
+	// `notifications` JSON column anymore. The migration's
+	// clearUserNotificationsJSON branch gracefully no-ops when the column
+	// doesn't exist — which is the steady state we end up in here. The
+	// guard we're asserting is that no rows leak into the new notifications
+	// table from migration: it's a wipe, not a drain.
+	if _, err := MigrateNotifications(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	var count int64
+	if err := db.Model(&Notification{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("migration should never insert into notifications, got %d", count)
+	}
+}
+
+// TestMigrateNotifications_UniqueIndexBlocksDuplicateEndpoints proves the
+// installed index actually prevents two rows from ever sharing an endpoint.
+// Without this constraint, the take-over logic in UpsertSubscriber can race
+// itself.
+func TestMigrateNotifications_UniqueIndexBlocksDuplicateEndpoints(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	if err := db.Create(&Subscriber{
+		Email:      "first@x",
+		Endpoint:   "https://push/dup",
+		LastSeenAt: time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	err := db.Create(&Subscriber{
+		Email:      "second@x",
+		Endpoint:   "https://push/dup",
+		LastSeenAt: time.Now(),
+	}).Error
+	if err == nil {
+		t.Fatalf("expected unique-index violation on duplicate endpoint")
+	}
+}

--- a/api/database/notifications.go
+++ b/api/database/notifications.go
@@ -1,0 +1,107 @@
+package database
+
+import (
+	"errors"
+	"time"
+
+	"prism/models"
+
+	"gorm.io/gorm"
+)
+
+// CreateNotification inserts one row into notifications. This is a single
+// INSERT — there is no read-modify-write — so two dispatchers can race to
+// write notifications for the same user without losing data, which was the
+// failure mode of the old UserData.Notifications JSON column.
+func CreateNotification(recipientEmail string, n models.Notification) error {
+	if recipientEmail == "" {
+		// Defensive — the dispatcher already filters empties, but cheap to
+		// short-circuit rather than insert a row no one can read.
+		return nil
+	}
+	row := Notification{
+		RecipientEmail:  recipientEmail,
+		Kind:            n.Kind,
+		Who:             n.Who,
+		What:            n.What,
+		Where:           n.Where,
+		VulnerabilityID: n.VulnerabilityID,
+		IsRead:          false,
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := db.Create(&row).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetNotifications returns the most recent notifications for one user. The
+// dropdown only renders a window of recent rows; older history stays in the
+// DB and is accessible via the same endpoint with a higher limit if needed.
+func GetNotifications(recipientEmail string, limit int) ([]models.Notification, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var rows []Notification
+	err := db.Where("recipient_email = ?", recipientEmail).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]models.Notification, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.Wire())
+	}
+	return out, nil
+}
+
+// MarkNotificationAsRead flips IsRead for one row, scoped by recipient so one
+// user can never mark another user's row.
+func MarkNotificationAsRead(recipientEmail string, id uint) error {
+	res := db.Model(&Notification{}).
+		Where("id = ? AND recipient_email = ?", id, recipientEmail).
+		Update("is_read", true)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// MarkAllNotificationsRead flips IsRead on every unread row for the user.
+// Replaces the old "delete everything" flow that the dropdown used to call
+// for clearing the badge.
+func MarkAllNotificationsRead(recipientEmail string) error {
+	return db.Model(&Notification{}).
+		Where("recipient_email = ? AND is_read = ?", recipientEmail, false).
+		Update("is_read", true).Error
+}
+
+// DeleteNotifications removes every row for one user. Kept for compatibility
+// with the existing DELETE /api/notification endpoint, but the dropdown now
+// uses MarkAllNotificationsRead so history survives "clear all".
+func DeleteNotifications(recipientEmail string) error {
+	if recipientEmail == "" {
+		return errors.New("recipient email required")
+	}
+	return db.Where("recipient_email = ?", recipientEmail).Delete(&Notification{}).Error
+}
+
+// Wire converts the DB row into the API DTO consumed by the frontend
+// dropdown. Keeps the wire shape stable while letting the DB schema evolve.
+func (n *Notification) Wire() models.Notification {
+	return models.Notification{
+		ID:              n.ID,
+		Who:             n.Who,
+		What:            n.What,
+		IsRead:          n.IsRead,
+		Where:           n.Where,
+		When:            n.CreatedAt,
+		Kind:            n.Kind,
+		VulnerabilityID: n.VulnerabilityID,
+	}
+}

--- a/api/database/notifications_test.go
+++ b/api/database/notifications_test.go
@@ -1,0 +1,215 @@
+package database
+
+import (
+	"sync"
+	"testing"
+
+	"prism/models"
+)
+
+func TestCreateNotification_InsertsRow(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	if err := CreateNotification("alice@x", models.Notification{
+		Kind:  models.NotificationKindNewVuln,
+		Who:   "bob@x",
+		What:  "New vuln",
+		Where: "/vulnerability/42/view",
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	rows, err := GetNotifications("alice@x", 10)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.Who != "bob@x" || got.What != "New vuln" || got.Where != "/vulnerability/42/view" {
+		t.Fatalf("row fields not preserved: %+v", got)
+	}
+	if got.IsRead {
+		t.Fatalf("new row should be unread")
+	}
+	if got.When.IsZero() {
+		t.Fatalf("created_at should be set")
+	}
+}
+
+func TestCreateNotification_EmptyRecipientIsNoop(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := CreateNotification("", models.Notification{What: "ghost"}); err != nil {
+		t.Fatalf("empty recipient should be no-op, got error: %v", err)
+	}
+	var count int64
+	if err := db.Model(&Notification{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no rows after empty-recipient create, got %d", count)
+	}
+}
+
+func TestGetNotifications_OnlyReturnsRecipientsRows(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	for _, who := range []string{"alice@x", "alice@x", "alice@x"} {
+		if err := CreateNotification(who, models.Notification{What: "alice msg"}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	if err := CreateNotification("bob@x", models.Notification{What: "bob msg"}); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	rows, err := GetNotifications("alice@x", 10)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 alice rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.What != "alice msg" {
+			t.Fatalf("leaked non-alice row: %+v", r)
+		}
+	}
+}
+
+func TestGetNotifications_HonoursLimitAndOrdersDesc(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	for i := 0; i < 5; i++ {
+		if err := CreateNotification("alice@x", models.Notification{What: "msg"}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	rows, err := GetNotifications("alice@x", 2)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows under limit, got %d", len(rows))
+	}
+	// IDs auto-increment so DESC ordering is observable through them.
+	if rows[0].ID < rows[1].ID {
+		t.Fatalf("expected DESC by created_at (proxied by id), got %d before %d", rows[0].ID, rows[1].ID)
+	}
+}
+
+func TestMarkNotificationAsRead_ScopedByRecipient(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := CreateNotification("alice@x", models.Notification{What: "for alice"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var row Notification
+	if err := db.Where("recipient_email = ?", "alice@x").First(&row).Error; err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Bob tries to flip Alice's row — should be a no-op (record not found
+	// at the scope, so the function returns gorm.ErrRecordNotFound).
+	if err := MarkNotificationAsRead("bob@x", row.ID); err == nil {
+		t.Fatalf("bob should not be able to mark alice's row read")
+	}
+	var unchanged Notification
+	_ = db.First(&unchanged, row.ID).Error
+	if unchanged.IsRead {
+		t.Fatalf("alice's row was flipped by bob, that's the bug we're guarding against")
+	}
+
+	// Alice can flip her own row.
+	if err := MarkNotificationAsRead("alice@x", row.ID); err != nil {
+		t.Fatalf("alice mark read: %v", err)
+	}
+	var after Notification
+	_ = db.First(&after, row.ID).Error
+	if !after.IsRead {
+		t.Fatalf("row should be marked read")
+	}
+}
+
+func TestMarkAllNotificationsRead_FlipsUnreadOnly(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := CreateNotification("alice@x", models.Notification{What: "one"}); err != nil {
+		t.Fatalf("create one: %v", err)
+	}
+	if err := CreateNotification("alice@x", models.Notification{What: "two"}); err != nil {
+		t.Fatalf("create two: %v", err)
+	}
+	if err := CreateNotification("bob@x", models.Notification{What: "bob"}); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	if err := MarkAllNotificationsRead("alice@x"); err != nil {
+		t.Fatalf("mark all: %v", err)
+	}
+
+	var unreadAlice int64
+	_ = db.Model(&Notification{}).
+		Where("recipient_email = ? AND is_read = ?", "alice@x", false).
+		Count(&unreadAlice).Error
+	if unreadAlice != 0 {
+		t.Fatalf("alice should have no unread rows, got %d", unreadAlice)
+	}
+
+	// Bob's row is untouched.
+	var bobRow Notification
+	_ = db.Where("recipient_email = ?", "bob@x").First(&bobRow).Error
+	if bobRow.IsRead {
+		t.Fatalf("bob's row was wrongly flipped: %+v", bobRow)
+	}
+}
+
+func TestDeleteNotifications_ScopedByRecipient(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := CreateNotification("alice@x", models.Notification{What: "a"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := CreateNotification("bob@x", models.Notification{What: "b"}); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+	if err := DeleteNotifications("alice@x"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	aliceRows, _ := GetNotifications("alice@x", 10)
+	if len(aliceRows) != 0 {
+		t.Fatalf("alice should have no rows, got %d", len(aliceRows))
+	}
+	bobRows, _ := GetNotifications("bob@x", 10)
+	if len(bobRows) != 1 {
+		t.Fatalf("bob should still have his row, got %d", len(bobRows))
+	}
+}
+
+// TestCreateNotification_ConcurrentWritesAllPersist is the regression guard
+// for the lost-update race that the old UserData.Notifications JSON column
+// had. N concurrent inserts must produce N rows; the old read-modify-write
+// JSON path lost all but one.
+func TestCreateNotification_ConcurrentWritesAllPersist(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	const n = 25
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			_ = CreateNotification("alice@x", models.Notification{
+				What: "concurrent",
+				Who:  "bob@x",
+			})
+			_ = i
+		}()
+	}
+	wg.Wait()
+
+	var count int64
+	if err := db.Model(&Notification{}).
+		Where("recipient_email = ?", "alice@x").
+		Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if int(count) != n {
+		t.Fatalf("expected all %d concurrent rows to land, got %d (this is the old JSON-blob race)", n, count)
+	}
+}

--- a/api/database/subscribers.go
+++ b/api/database/subscribers.go
@@ -14,39 +14,69 @@ import (
 // key; without it, the take-over semantics cannot be enforced.
 var ErrSubscriberMissingEndpoint = errors.New("push subscription is missing endpoint")
 
-// UpsertSubscriber binds the given push endpoint to the given email, taking it
-// over from any other email that previously owned it.
+// ErrSubscriberEndpointClaimed is returned when a user tries to register a
+// push endpoint that's already bound to a different email and the request
+// can't prove ownership of the underlying browser subscription (its
+// p256dh/auth keys don't match what we have on file). Refusing the take-over
+// here is what stops an attacker who only knows an endpoint URL from
+// deregistering or hijacking somebody else's subscription. The legitimate
+// shared-browser path still works because the same browser returns the same
+// keys from pushManager.getSubscription on every login.
+var ErrSubscriberEndpointClaimed = errors.New("push endpoint is registered to another account")
+
+// UpsertSubscriber binds the given push endpoint to the given email, taking
+// it over from any other email that previously owned it — but only when the
+// caller can prove possession of the underlying browser subscription by
+// presenting the same p256dh/auth keys.
 //
-// This is the core fix for the cross-user push delivery bug: a single browser
-// only ever has one row in subscribers, owned by the user who most recently
-// enabled push on that device. When Alice subscribes on browser B then logs
-// out, Alice's row keeps endpoint X. If Bob then logs in on browser B and
-// enables push, browser B returns the same endpoint X (pushManager is per
-// browser-installation, not per user), and this upsert rebinds X to Bob.
-// Alice's row for X is gone — server pushes for Alice no longer land on
-// Bob's screen.
+// This is the core fix for the cross-user push delivery bug: a single
+// browser only ever has one row in subscribers, owned by the user who most
+// recently enabled push on that device. When Alice subscribes on browser B
+// then logs out, Alice's row keeps endpoint X. If Bob then logs in on
+// browser B and enables push, browser B returns the same endpoint X *and*
+// the same keys from pushManager.getSubscription (push endpoints are
+// per-browser-installation, and so are their keys). The keys-match check
+// lets this legitimate take-over through, while blocking an attacker who
+// only knows the endpoint URL (or knows the URL but not the keys) from
+// deregistering or hijacking the victim's subscription.
 //
 // We don't use ON CONFLICT here because GORM/sqlite ON CONFLICT requires a
-// UNIQUE index, and the migration installs that index. We instead delete any
-// other row owning this endpoint inside a single transaction, then upsert by
-// (email, endpoint).
+// UNIQUE index, and the migration installs that index. We do the conflict
+// check + take-over + upsert inside a single transaction.
 func UpsertSubscriber(email string, sub webpush.Subscription, userAgent string) error {
 	endpoint := strings.TrimSpace(sub.Endpoint)
 	if endpoint == "" {
 		return ErrSubscriberMissingEndpoint
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
-		// Take-over: delete any row pointing at this endpoint that doesn't
-		// belong to the current user. Same email/endpoint is left in place and
-		// re-fetched below so the upsert is a single round-trip.
-		if err := tx.Unscoped().
-			Where("endpoint = ? AND email <> ?", endpoint, email).
-			Delete(&Subscriber{}).Error; err != nil {
+		// First check whether a different email already owns this endpoint.
+		// Take-over is only permitted when the requesting browser can present
+		// the same p256dh+auth pair we have on file — that's the proof the
+		// browser actually holds the underlying push subscription. Without
+		// the check, any authed user could yank another user's row by
+		// knowing only the endpoint URL.
+		var conflict Subscriber
+		err := tx.Where("endpoint = ? AND email <> ?", endpoint, email).
+			First(&conflict).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return err
+		}
+		if err == nil {
+			if sub.Keys.P256dh == "" || sub.Keys.Auth == "" ||
+				sub.Keys.P256dh != conflict.P256dh ||
+				sub.Keys.Auth != conflict.Auth {
+				return ErrSubscriberEndpointClaimed
+			}
+			// Keys match — rebind the row to the new owner.
+			if err := tx.Unscoped().
+				Where("endpoint = ? AND email <> ?", endpoint, email).
+				Delete(&Subscriber{}).Error; err != nil {
+				return err
+			}
 		}
 
 		var existing Subscriber
-		err := tx.Where("email = ? AND endpoint = ?", email, endpoint).
+		err = tx.Where("email = ? AND endpoint = ?", email, endpoint).
 			First(&existing).Error
 		now := time.Now().UTC()
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/api/database/subscribers.go
+++ b/api/database/subscribers.go
@@ -1,0 +1,127 @@
+package database
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/SherClockHolmes/webpush-go"
+	"gorm.io/gorm"
+)
+
+// ErrSubscriberMissingEndpoint is returned when an upsert is attempted with a
+// subscription that lacks an endpoint. Endpoint is the cross-user uniqueness
+// key; without it, the take-over semantics cannot be enforced.
+var ErrSubscriberMissingEndpoint = errors.New("push subscription is missing endpoint")
+
+// UpsertSubscriber binds the given push endpoint to the given email, taking it
+// over from any other email that previously owned it.
+//
+// This is the core fix for the cross-user push delivery bug: a single browser
+// only ever has one row in subscribers, owned by the user who most recently
+// enabled push on that device. When Alice subscribes on browser B then logs
+// out, Alice's row keeps endpoint X. If Bob then logs in on browser B and
+// enables push, browser B returns the same endpoint X (pushManager is per
+// browser-installation, not per user), and this upsert rebinds X to Bob.
+// Alice's row for X is gone — server pushes for Alice no longer land on
+// Bob's screen.
+//
+// We don't use ON CONFLICT here because GORM/sqlite ON CONFLICT requires a
+// UNIQUE index, and the migration installs that index. We instead delete any
+// other row owning this endpoint inside a single transaction, then upsert by
+// (email, endpoint).
+func UpsertSubscriber(email string, sub webpush.Subscription, userAgent string) error {
+	endpoint := strings.TrimSpace(sub.Endpoint)
+	if endpoint == "" {
+		return ErrSubscriberMissingEndpoint
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		// Take-over: delete any row pointing at this endpoint that doesn't
+		// belong to the current user. Same email/endpoint is left in place and
+		// re-fetched below so the upsert is a single round-trip.
+		if err := tx.Unscoped().
+			Where("endpoint = ? AND email <> ?", endpoint, email).
+			Delete(&Subscriber{}).Error; err != nil {
+			return err
+		}
+
+		var existing Subscriber
+		err := tx.Where("email = ? AND endpoint = ?", email, endpoint).
+			First(&existing).Error
+		now := time.Now().UTC()
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return tx.Create(&Subscriber{
+				Email:      email,
+				Endpoint:   endpoint,
+				P256dh:     sub.Keys.P256dh,
+				Auth:       sub.Keys.Auth,
+				UserAgent:  userAgent,
+				LastSeenAt: now,
+			}).Error
+		}
+		if err != nil {
+			return err
+		}
+		return tx.Model(&existing).Updates(map[string]any{
+			"p256dh":       sub.Keys.P256dh,
+			"auth":         sub.Keys.Auth,
+			"user_agent":   userAgent,
+			"last_seen_at": now,
+		}).Error
+	})
+}
+
+// DeleteSubscriberByEndpoint removes the current user's subscription for one
+// device. Scoped by email so users can't yank each other's subscriptions by
+// guessing endpoints.
+func DeleteSubscriberByEndpoint(email, endpoint string) error {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ErrSubscriberMissingEndpoint
+	}
+	return db.Unscoped().
+		Where("email = ? AND endpoint = ?", email, endpoint).
+		Delete(&Subscriber{}).Error
+}
+
+// DeleteDeadSubscriber removes a row when the push provider says the endpoint
+// is gone (404/410). Called from the dispatcher so dead devices age out of
+// the table on their own — no manual cleanup needed.
+func DeleteDeadSubscriber(endpoint string) error {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ErrSubscriberMissingEndpoint
+	}
+	return db.Unscoped().Where("endpoint = ?", endpoint).Delete(&Subscriber{}).Error
+}
+
+// ListSubscribersForEmail returns every subscription belonging to one user
+// (one user can have several devices). The dispatcher pushes to all of them.
+func ListSubscribersForEmail(email string) ([]Subscriber, error) {
+	var rows []Subscriber
+	err := db.Where("email = ? AND endpoint <> ''", email).Find(&rows).Error
+	return rows, err
+}
+
+// ListSubscribersForEmails is the bulk variant used by SendMessage so the
+// dispatcher does a single SELECT instead of one per recipient.
+func ListSubscribersForEmails(emails []string) ([]Subscriber, error) {
+	if len(emails) == 0 {
+		return nil, nil
+	}
+	var rows []Subscriber
+	err := db.Where("email IN ? AND endpoint <> ''", emails).Find(&rows).Error
+	return rows, err
+}
+
+// AsPushSubscription rebuilds the webpush-go subscription struct from the
+// typed columns so the dispatcher can hand it straight to SendNotification.
+func (s *Subscriber) AsPushSubscription() webpush.Subscription {
+	return webpush.Subscription{
+		Endpoint: s.Endpoint,
+		Keys: webpush.Keys{
+			Auth:   s.Auth,
+			P256dh: s.P256dh,
+		},
+	}
+}

--- a/api/database/subscribers_test.go
+++ b/api/database/subscribers_test.go
@@ -1,0 +1,263 @@
+package database
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SherClockHolmes/webpush-go"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// testDBCounter gives each setup call a unique in-memory database. Using
+// `file::memory:?cache=shared` without a unique name shares one backing
+// store across every open() in the process, so tests in the same package
+// leak state into each other — which is exactly the failure mode the
+// dashboard tests dodge by having only one test per file.
+var testDBCounter uint64
+
+// setupNotificationsTestDB swaps the package-level db for an isolated
+// in-memory sqlite, auto-migrates the subscriber + notification + user_data
+// schemas, and runs the notification migration so the UNIQUE endpoint index
+// is installed — which is what UpsertSubscriber's take-over semantics
+// actually rely on.
+func setupNotificationsTestDB(t *testing.T) func() {
+	t.Helper()
+	original := db
+	dsn := fmt.Sprintf("file:notif_test_%d?mode=memory&cache=shared",
+		atomic.AddUint64(&testDBCounter, 1))
+	testDB, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	// SQLite is single-writer at the file/cache level, and the in-memory
+	// shared-cache mode used here aggravates SQLITE_BUSY when GORM opens
+	// multiple connections. Pin to one connection so concurrent goroutines
+	// in the race-regression test serialize cleanly through the driver
+	// instead of fighting the lock. Production InitDB caps to 10 + sets
+	// busy_timeout via WAL pragmas; the equivalent for an in-memory DB is
+	// just "one connection".
+	sqlDB, err := testDB.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := testDB.Exec("PRAGMA busy_timeout = 5000;").Error; err != nil {
+		t.Fatalf("busy_timeout: %v", err)
+	}
+	if err := testDB.AutoMigrate(&Subscriber{}, &Notification{}, &UserData{}); err != nil {
+		t.Fatalf("migrate schema: %v", err)
+	}
+	db = testDB
+	if _, err := MigrateNotifications(); err != nil {
+		t.Fatalf("notification migration: %v", err)
+	}
+	return func() { db = original }
+}
+
+func makeSub(endpoint string) webpush.Subscription {
+	return webpush.Subscription{
+		Endpoint: endpoint,
+		Keys: webpush.Keys{
+			P256dh: "p256_" + endpoint,
+			Auth:   "auth_" + endpoint,
+		},
+	}
+}
+
+func TestUpsertSubscriber_CreatesRow(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	if err := UpsertSubscriber("alice@x", makeSub("https://push/alice-1"), "ua/1"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	rows, err := ListSubscribersForEmail("alice@x")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.Endpoint != "https://push/alice-1" || got.P256dh != "p256_https://push/alice-1" || got.UserAgent != "ua/1" {
+		t.Fatalf("row not populated as expected: %+v", got)
+	}
+	if got.LastSeenAt.IsZero() {
+		t.Fatalf("last_seen_at should be set")
+	}
+}
+
+func TestUpsertSubscriber_SameOwnerUpdatesNotDuplicates(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	endpoint := "https://push/alice-2"
+	if err := UpsertSubscriber("alice@x", makeSub(endpoint), "ua/old"); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	// Resubscribe with the same endpoint but new keys (this is what the
+	// browser hands the server on every page load after permission was
+	// granted; the data shouldn't accumulate rows).
+	rotated := makeSub(endpoint)
+	rotated.Keys.P256dh = "rotated-p256"
+	rotated.Keys.Auth = "rotated-auth"
+	if err := UpsertSubscriber("alice@x", rotated, "ua/new"); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	rows, err := ListSubscribersForEmail("alice@x")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after re-subscribe, got %d", len(rows))
+	}
+	if rows[0].P256dh != "rotated-p256" || rows[0].Auth != "rotated-auth" || rows[0].UserAgent != "ua/new" {
+		t.Fatalf("keys not rotated: %+v", rows[0])
+	}
+}
+
+// TestUpsertSubscriber_TakesOverFromDifferentOwner is the core regression
+// guard for the cross-user push delivery bug. Alice subscribes on a browser
+// (endpoint X bound to alice@x). Bob then logs in on the same browser and
+// subscribes — the same endpoint comes back from pushManager because it's
+// per-browser, not per-user. After Bob's upsert, only Bob should own X.
+func TestUpsertSubscriber_TakesOverFromDifferentOwner(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	endpoint := "https://push/shared-browser"
+	if err := UpsertSubscriber("alice@x", makeSub(endpoint), "shared"); err != nil {
+		t.Fatalf("alice upsert: %v", err)
+	}
+	if err := UpsertSubscriber("bob@x", makeSub(endpoint), "shared"); err != nil {
+		t.Fatalf("bob upsert: %v", err)
+	}
+
+	aliceRows, _ := ListSubscribersForEmail("alice@x")
+	bobRows, _ := ListSubscribersForEmail("bob@x")
+	if len(aliceRows) != 0 {
+		t.Fatalf("alice should no longer own endpoint, got %d rows", len(aliceRows))
+	}
+	if len(bobRows) != 1 || bobRows[0].Endpoint != endpoint {
+		t.Fatalf("bob should own endpoint after take-over, got %+v", bobRows)
+	}
+
+	// And the (endpoint -> recipients) view used by the dispatcher must not
+	// see any alice rows for this endpoint.
+	all, _ := ListSubscribersForEmails([]string{"alice@x", "bob@x"})
+	for _, r := range all {
+		if r.Endpoint == endpoint && r.Email == "alice@x" {
+			t.Fatalf("stale alice row for endpoint still in result set: %+v", r)
+		}
+	}
+}
+
+func TestUpsertSubscriber_RejectsMissingEndpoint(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	err := UpsertSubscriber("alice@x", webpush.Subscription{}, "")
+	if err == nil {
+		t.Fatalf("expected error for empty endpoint")
+	}
+}
+
+func TestDeleteSubscriberByEndpoint_ScopedToOwner(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := UpsertSubscriber("alice@x", makeSub("https://push/a"), ""); err != nil {
+		t.Fatalf("alice upsert: %v", err)
+	}
+	if err := UpsertSubscriber("bob@x", makeSub("https://push/b"), ""); err != nil {
+		t.Fatalf("bob upsert: %v", err)
+	}
+
+	// Bob tries to delete by an endpoint he doesn't own — should be a no-op,
+	// not a leak that nukes Alice's row.
+	if err := DeleteSubscriberByEndpoint("bob@x", "https://push/a"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	aliceRows, _ := ListSubscribersForEmail("alice@x")
+	if len(aliceRows) != 1 {
+		t.Fatalf("alice's row was wrongly removed by bob, got %d rows", len(aliceRows))
+	}
+
+	// Bob deletes his own row — should disappear.
+	if err := DeleteSubscriberByEndpoint("bob@x", "https://push/b"); err != nil {
+		t.Fatalf("delete own: %v", err)
+	}
+	bobRows, _ := ListSubscribersForEmail("bob@x")
+	if len(bobRows) != 0 {
+		t.Fatalf("bob's own row should be gone, got %d", len(bobRows))
+	}
+}
+
+func TestDeleteDeadSubscriber_RemovesAllRowsForEndpoint(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := UpsertSubscriber("alice@x", makeSub("https://push/dead"), ""); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := DeleteDeadSubscriber("https://push/dead"); err != nil {
+		t.Fatalf("dead delete: %v", err)
+	}
+	rows, _ := ListSubscribersForEmail("alice@x")
+	if len(rows) != 0 {
+		t.Fatalf("dead endpoint not pruned: %d rows", len(rows))
+	}
+}
+
+func TestListSubscribersForEmail_OnlyReturnsOwnersRows(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+	if err := UpsertSubscriber("alice@x", makeSub("https://push/a1"), ""); err != nil {
+		t.Fatalf("a1: %v", err)
+	}
+	if err := UpsertSubscriber("alice@x", makeSub("https://push/a2"), ""); err != nil {
+		t.Fatalf("a2: %v", err)
+	}
+	if err := UpsertSubscriber("bob@x", makeSub("https://push/b1"), ""); err != nil {
+		t.Fatalf("b1: %v", err)
+	}
+	rows, err := ListSubscribersForEmail("alice@x")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 alice rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.Email != "alice@x" {
+			t.Fatalf("leaked non-alice row: %+v", r)
+		}
+	}
+}
+
+// TestUpsertSubscriber_ConcurrentSameEndpointConvergesToOneOwner stresses the
+// take-over path: two users racing to claim the same endpoint must end with
+// exactly one row bound to whichever upsert won. The UNIQUE index installed
+// by the migration plus the transaction inside UpsertSubscriber is what
+// makes this safe.
+func TestUpsertSubscriber_ConcurrentSameEndpointConvergesToOneOwner(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	endpoint := "https://push/race"
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_ = UpsertSubscriber("alice@x", makeSub(endpoint), "")
+	}()
+	go func() {
+		defer wg.Done()
+		_ = UpsertSubscriber("bob@x", makeSub(endpoint), "")
+	}()
+	wg.Wait()
+
+	var rows []Subscriber
+	if err := db.Where("endpoint = ?", endpoint).Find(&rows).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly one row after race, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].Email != "alice@x" && rows[0].Email != "bob@x" {
+		t.Fatalf("unexpected owner after race: %+v", rows[0])
+	}
+}

--- a/api/database/subscribers_test.go
+++ b/api/database/subscribers_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -158,6 +159,80 @@ func TestUpsertSubscriber_RejectsMissingEndpoint(t *testing.T) {
 	err := UpsertSubscriber("alice@x", webpush.Subscription{}, "")
 	if err == nil {
 		t.Fatalf("expected error for empty endpoint")
+	}
+}
+
+// TestUpsertSubscriber_RejectsTakeOverWithoutMatchingKeys is the regression
+// guard for the pentest F-01 finding: an authed user must not be able to
+// yank another user's subscription by knowing only the endpoint URL. The
+// take-over is allowed only when the requesting browser can prove it holds
+// the underlying subscription by presenting the same p256dh/auth keys.
+func TestUpsertSubscriber_RejectsTakeOverWithoutMatchingKeys(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	endpoint := "https://push/contested"
+	original := webpush.Subscription{
+		Endpoint: endpoint,
+		Keys:     webpush.Keys{P256dh: "real-p256", Auth: "real-auth"},
+	}
+	if err := UpsertSubscriber("alice@x", original, "alice-ua"); err != nil {
+		t.Fatalf("alice upsert: %v", err)
+	}
+
+	// Attacker knows the URL but not the keys.
+	urlOnly := webpush.Subscription{
+		Endpoint: endpoint,
+		// p256dh + auth empty (the live pentest attack)
+	}
+	if err := UpsertSubscriber("bob@x", urlOnly, "bob-ua"); !errors.Is(err, ErrSubscriberEndpointClaimed) {
+		t.Fatalf("expected ErrSubscriberEndpointClaimed for url-only take-over, got %v", err)
+	}
+	// Attacker guesses wrong keys.
+	wrongKeys := webpush.Subscription{
+		Endpoint: endpoint,
+		Keys:     webpush.Keys{P256dh: "guessed", Auth: "guessed"},
+	}
+	if err := UpsertSubscriber("bob@x", wrongKeys, "bob-ua"); !errors.Is(err, ErrSubscriberEndpointClaimed) {
+		t.Fatalf("expected ErrSubscriberEndpointClaimed for wrong-keys take-over, got %v", err)
+	}
+
+	// Alice's row is intact.
+	rows, err := ListSubscribersForEmail("alice@x")
+	if err != nil {
+		t.Fatalf("list alice: %v", err)
+	}
+	if len(rows) != 1 || rows[0].P256dh != "real-p256" || rows[0].Auth != "real-auth" {
+		t.Fatalf("alice's row was clobbered by failed take-over: %+v", rows)
+	}
+	// Bob has no row for this endpoint.
+	bobRows, _ := ListSubscribersForEmail("bob@x")
+	if len(bobRows) != 0 {
+		t.Fatalf("bob should have no row after rejected take-over, got %+v", bobRows)
+	}
+}
+
+// TestUpsertSubscriber_AllowsTakeOverWhenKeysMatch covers the legitimate
+// shared-browser path: Alice logs out, Bob logs in on the same browser, the
+// browser returns the same endpoint *and* the same keys from
+// pushManager.getSubscription, take-over succeeds.
+func TestUpsertSubscriber_AllowsTakeOverWhenKeysMatch(t *testing.T) {
+	defer setupNotificationsTestDB(t)()
+
+	endpoint := "https://push/shared"
+	sub := webpush.Subscription{
+		Endpoint: endpoint,
+		Keys:     webpush.Keys{P256dh: "shared-p256", Auth: "shared-auth"},
+	}
+	if err := UpsertSubscriber("alice@x", sub, ""); err != nil {
+		t.Fatalf("alice upsert: %v", err)
+	}
+	if err := UpsertSubscriber("bob@x", sub, ""); err != nil {
+		t.Fatalf("bob take-over with matching keys should succeed: %v", err)
+	}
+	aliceRows, _ := ListSubscribersForEmail("alice@x")
+	bobRows, _ := ListSubscribersForEmail("bob@x")
+	if len(aliceRows) != 0 || len(bobRows) != 1 || bobRows[0].Endpoint != endpoint {
+		t.Fatalf("matching-keys take-over didn't rebind cleanly: alice=%v bob=%v", aliceRows, bobRows)
 	}
 }
 

--- a/api/database/test_seam.go
+++ b/api/database/test_seam.go
@@ -1,0 +1,19 @@
+package database
+
+import "gorm.io/gorm"
+
+// SetDBForTest swaps the package-level db handle and returns the previous
+// one. Only meant to be called from tests in other packages (notably
+// prism/routes) that need to point the data layer at an in-memory sqlite.
+// Pair every call with a defer to restore.
+func SetDBForTest(testDB *gorm.DB) *gorm.DB {
+	prev := db
+	db = testDB
+	return prev
+}
+
+// DBForTest exposes the package-level db handle for tests that need to seed
+// rows directly through GORM without going through the typed helpers.
+func DBForTest() *gorm.DB {
+	return db
+}

--- a/api/event/eventQueue.go
+++ b/api/event/eventQueue.go
@@ -175,13 +175,11 @@ func getUrlFor(channel string, timestamp string, workspace string) string {
 }
 
 func sendBrowserNotification(event database.EventQueue) {
-
 	if event.Kind != models.NewVulnerability {
 		return
 	}
 
 	finding, err := database.GetJSONData(event.TableID)
-
 	if err != nil {
 		updateEvent(event, err)
 		log.Printf("Error getting the event from table %s", err)
@@ -189,48 +187,52 @@ func sendBrowserNotification(event database.EventQueue) {
 	}
 
 	var vulnData Vulnerability
-	err = json.Unmarshal(finding.Vulnerability, &vulnData)
-	if err != nil {
+	if err := json.Unmarshal(finding.Vulnerability, &vulnData); err != nil {
 		updateEvent(event, err)
-		log.Printf("Error unmarshelling the event %s", err)
-
+		log.Printf("Error unmarshalling the event %s", err)
 		return
 	}
 
-	var data VulnerabilityData
-	data.Vulnerability = vulnData
-	data.URL = "/vulnerability/" + strconv.FormatUint(uint64(finding.ID), 10) + "/view"
+	url := "/vulnerability/" + strconv.FormatUint(uint64(finding.ID), 10) + "/view"
 
-	usersToNotify := make(map[string]bool)
+	recipients := []string{}
 	var projectName string
-
 	if finding.ProjectID != nil {
 		project, _ := database.GetProject(*finding.ProjectID)
 		projectName = project.ProjectName
-
-		// Split the HackerName string by comma and add each name to the map
-		for _, hacker := range strings.Split(project.HackerName, ",") {
-			if hacker != "" { // Make sure the string is not empty
-				usersToNotify[hacker] = true
-			}
-		}
-
-		// Split the ClientEmail string by comma and add each email to the map
-		for _, email := range strings.Split(project.ClientEmail, ",") {
-			if email != "" { // Make sure the string is not empty
-				usersToNotify[email] = true
-			}
-		}
+		recipients = append(recipients, splitMembers(project.HackerName)...)
+		recipients = append(recipients, splitMembers(project.ClientEmail)...)
 	}
 
-	// missing global users
-	// missing manually subscribed to project notification users
-
-	err = routes.SendMessage(projectName, "New vulnerability "+data.Vulnerability.Title, data.URL, finding.FoundBy, finding.FoundBy, usersToNotify)
+	err = routes.Dispatch(routes.DispatchRequest{
+		Kind:            models.NotificationKindNewVuln,
+		VulnerabilityID: finding.ID,
+		ActorEmail:      finding.FoundBy,
+		Recipients:      recipients,
+		Title:           projectName,
+		Body:            "New vulnerability " + vulnData.Title,
+		URL:             url,
+	})
 	if err != nil {
 		log.Printf("Error sending the message %s", err)
 	}
 	updateEvent(event, err)
+}
+
+// splitMembers parses one of the comma-separated email columns on
+// ProjectData. The Dispatcher does its own trim+lowercase pass, but doing it
+// here too keeps both halves of the code paths consistent and makes the
+// recipient list easier to reason about in logs.
+func splitMembers(commaSeparated string) []string {
+	parts := strings.Split(commaSeparated, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func updateEvent(event database.EventQueue, err error) {
@@ -246,64 +248,39 @@ func updateEvent(event database.EventQueue, err error) {
 }
 
 func sendCommentsNotification(event database.EventQueue) {
-
 	if event.Kind != models.NewComment {
 		return
 	}
 
 	finding, err := database.GetJSONData(event.TableID)
-
 	if err != nil {
 		return
 	}
-
-	var vulnData Vulnerability
-	err = json.Unmarshal(finding.Vulnerability, &vulnData)
-	if err != nil {
-		updateEvent(event, err)
-		return
-	}
-
-	var data VulnerabilityData
-	data.Vulnerability = vulnData
 
 	vulnerability, _ := database.GetJSONData(finding.ID)
 
 	var comments []models.Comment
-
 	_ = json.Unmarshal([]byte(vulnerability.Comments), &comments)
 
-	usersToNotify := make(map[string]bool)
-
+	recipients := []string{vulnerability.FoundBy}
 	var lastComment models.Comment
-
-	// Ensure we have at least one comment to initialize lastComment
 	if len(comments) > 0 {
 		lastComment = comments[0]
 	}
-
 	for _, comment := range comments {
-		usersToNotify[comment.UserEmail] = true
+		recipients = append(recipients, comment.UserEmail)
 		if lastComment.CreatedAt.Before(comment.CreatedAt) {
 			lastComment = comment
 		}
 	}
 
-	data.URL = "/vulnerability/" + strconv.FormatUint(uint64(finding.ID), 10) + "/view#" + lastComment.ID
-
-	// usersToNotify = append(usersToNotify, vulnerability.FoundBy)
-	usersToNotify[vulnerability.FoundBy] = true
-
 	if finding.ProjectID != nil {
 		project, _ := database.GetProject(*finding.ProjectID)
-		var projectUsers []string
-		projectUsers = append(projectUsers, strings.Split(project.HackerName, ",")...)
-		projectUsers = append(projectUsers, strings.Split(project.ClientEmail, ",")...)
-
-		for _, user := range projectUsers {
-			usersToNotify[user] = true
-		}
+		recipients = append(recipients, splitMembers(project.HackerName)...)
+		recipients = append(recipients, splitMembers(project.ClientEmail)...)
 	}
+
+	url := "/vulnerability/" + strconv.FormatUint(uint64(finding.ID), 10) + "/view#" + lastComment.ID
 
 	var message string
 	if len(lastComment.Text) > 50 {
@@ -312,7 +289,15 @@ func sendCommentsNotification(event database.EventQueue) {
 		message = "💬 " + lastComment.Text
 	}
 
-	err = routes.SendMessage("PRISM", message, data.URL, finding.FoundBy, lastComment.UserEmail, usersToNotify)
+	err = routes.Dispatch(routes.DispatchRequest{
+		Kind:            models.NotificationKindNewComment,
+		VulnerabilityID: finding.ID,
+		ActorEmail:      lastComment.UserEmail,
+		Recipients:      recipients,
+		Title:           "PRISM",
+		Body:            message,
+		URL:             url,
+	})
 	updateEvent(event, err)
 }
 

--- a/api/main.go
+++ b/api/main.go
@@ -43,6 +43,12 @@ func main() {
 		log.Printf("attachment migration: %s", report.String())
 	}
 
+	// Move legacy per-user notification JSON blobs into the new notifications
+	// table, backfill typed columns on the subscribers table, dedupe shared
+	// endpoints across users (the cross-user bug, expressed as data), and
+	// install the UNIQUE endpoint index. Idempotent.
+	database.RunNotificationMigrationOnce()
+
 	initSessionDatabase()
 	sessionStore := session.NewSessionStore(session_db)
 	session.LoadSessionStore(sessionStore)
@@ -99,8 +105,11 @@ func main() {
 		apiRoutes.GET("/notification/publicKey", routes.GetNotificationPublicKey)
 		apiRoutes.GET("/notification", routes.GetNotificationsHandler)
 		apiRoutes.DELETE("/notification", routes.DeleteNotificationsHandler)
-		apiRoutes.PUT("/notification/:time/read", routes.MarkNotificationReadHandler)
+		apiRoutes.PUT("/notification/read-all", routes.MarkAllReadHandler)
+		apiRoutes.PUT("/notification/:id/read", routes.MarkNotificationReadHandler)
 		apiRoutes.POST("/notification/subscribe", routes.SubscribeNotification)
+		apiRoutes.DELETE("/notification/subscribe", routes.UnsubscribeNotification)
+		apiRoutes.GET("/notification/devices", routes.ListDevices)
 
 		apiRoutes.GET("/dashboard", routes.HandleDashboard)
 

--- a/api/models/notification.go
+++ b/api/models/notification.go
@@ -4,10 +4,22 @@ import (
 	"time"
 )
 
+// Notification is the wire shape returned to the frontend. The DB row lives in
+// the database package; this struct mirrors the JSON the dropdown consumes.
 type Notification struct {
-	Who    string    `json:"who"`
-	What   string    `json:"what"`
-	IsRead bool      `json:"read"`
-	Where  string    `json:"where"`
-	When   time.Time `json:"when"`
+	ID              uint      `json:"id"`
+	Who             string    `json:"who"`
+	What            string    `json:"what"`
+	IsRead          bool      `json:"read"`
+	Where           string    `json:"where"`
+	When            time.Time `json:"when"`
+	Kind            string    `json:"kind,omitempty"`
+	VulnerabilityID *uint     `json:"vulnerabilityId,omitempty"`
 }
+
+// NotificationKind values are stored on the row so the UI and the dispatcher
+// can filter behaviour by event type without re-parsing `what`.
+const (
+	NotificationKindNewVuln    = "new_vuln"
+	NotificationKindNewComment = "new_comment"
+)

--- a/api/models/user.go
+++ b/api/models/user.go
@@ -1,5 +1,46 @@
 package models
 
+// UserSettings is persisted as a JSON blob in user_data.settings. Unknown keys
+// are tolerated on read so older clients can deserialize newer payloads.
 type UserSettings struct {
-	SwimlaneUsers []string `json:"swimlaneUsers" gorm:"swimlaneUsers"`
+	SwimlaneUsers     []string          `json:"swimlaneUsers" gorm:"swimlaneUsers"`
+	NotificationPrefs NotificationPrefs `json:"notificationPrefs"`
+}
+
+// NotificationPrefs is the per-user opt-out matrix for the two channels and
+// two event kinds. All four flags default to true (notifications enabled);
+// the dispatcher only suppresses delivery when a flag has been explicitly set
+// to false. Unset fields decode as false in Go but are normalised to true by
+// EffectiveNotificationPrefs at read time.
+type NotificationPrefs struct {
+	InAppNewVuln    *bool `json:"inAppNewVuln,omitempty"`
+	InAppNewComment *bool `json:"inAppNewComment,omitempty"`
+	PushNewVuln     *bool `json:"pushNewVuln,omitempty"`
+	PushNewComment  *bool `json:"pushNewComment,omitempty"`
+}
+
+// EffectiveNotificationPrefs replaces nil pointers with `true`, giving the
+// dispatcher a flag-set with no ambiguity between "unset" and "off". A user
+// who has never touched their settings gets every notification.
+func (p NotificationPrefs) Effective() ResolvedNotificationPrefs {
+	return ResolvedNotificationPrefs{
+		InAppNewVuln:    boolOrTrue(p.InAppNewVuln),
+		InAppNewComment: boolOrTrue(p.InAppNewComment),
+		PushNewVuln:     boolOrTrue(p.PushNewVuln),
+		PushNewComment:  boolOrTrue(p.PushNewComment),
+	}
+}
+
+type ResolvedNotificationPrefs struct {
+	InAppNewVuln    bool
+	InAppNewComment bool
+	PushNewVuln     bool
+	PushNewComment  bool
+}
+
+func boolOrTrue(b *bool) bool {
+	if b == nil {
+		return true
+	}
+	return *b
 }

--- a/api/models/user_test.go
+++ b/api/models/user_test.go
@@ -1,0 +1,34 @@
+package models
+
+import "testing"
+
+func TestNotificationPrefs_EffectiveDefaultsToAllOn(t *testing.T) {
+	// All four fields nil — the "user never touched their settings" state.
+	got := NotificationPrefs{}.Effective()
+	if !got.InAppNewVuln || !got.InAppNewComment || !got.PushNewVuln || !got.PushNewComment {
+		t.Fatalf("default prefs should be all-on, got %+v", got)
+	}
+}
+
+func TestNotificationPrefs_EffectiveRespectsExplicitOff(t *testing.T) {
+	off := false
+	on := true
+	got := NotificationPrefs{
+		InAppNewVuln:    &off,
+		InAppNewComment: &on,
+		PushNewVuln:     nil,    // unset -> default on
+		PushNewComment:  &off,
+	}.Effective()
+	if got.InAppNewVuln {
+		t.Fatalf("explicit false should win for InAppNewVuln")
+	}
+	if !got.InAppNewComment {
+		t.Fatalf("explicit true should win for InAppNewComment")
+	}
+	if !got.PushNewVuln {
+		t.Fatalf("nil should default to true for PushNewVuln")
+	}
+	if got.PushNewComment {
+		t.Fatalf("explicit false should win for PushNewComment")
+	}
+}

--- a/api/routes/notification.go
+++ b/api/routes/notification.go
@@ -1,11 +1,16 @@
 package routes
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"prism/database"
@@ -15,6 +20,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// PushMessage is the JSON payload delivered to service-worker.js. Mirrors the
+// fields the existing SW reads (title/body/url); keep new fields optional so
+// older service workers still render the basics.
 type PushMessage struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
@@ -24,7 +32,6 @@ type PushMessage struct {
 var (
 	vapidPublicKey  string
 	vapidPrivateKey string
-	err             error
 )
 
 const (
@@ -33,7 +40,7 @@ const (
 )
 
 func InitNotification() {
-
+	var err error
 	for retries := 0; retries < maxRetries; retries++ {
 		var vapidKey string
 		vapidKey, err = database.GetVAAPIpublicKey()
@@ -51,8 +58,7 @@ func InitNotification() {
 	}
 
 	if vapidPublicKey == "" {
-		err = createAndPersistVAAPIKeys()
-		if err != nil {
+		if err := createAndPersistVAAPIKeys(); err != nil {
 			log.Fatalf("Unable to generate VAAPI keys: %v", err)
 		}
 	} else {
@@ -64,83 +70,94 @@ func InitNotification() {
 }
 
 func createAndPersistVAAPIKeys() error {
-	vapidPrivateKey, vapidPublicKey, err = webpush.GenerateVAPIDKeys()
+	priv, pub, err := webpush.GenerateVAPIDKeys()
 	if err != nil {
 		return fmt.Errorf("Unable to generate VAAPI keys: %v", err)
 	}
-	err = database.CreateVAAPIprivateKey(vapidPrivateKey, vapidPublicKey)
-	if err != nil {
+	vapidPrivateKey = priv
+	vapidPublicKey = pub
+	if err := database.CreateVAAPIprivateKey(vapidPrivateKey, vapidPublicKey); err != nil {
 		return fmt.Errorf("Unable to store VAAPI keys: %v", err)
 	}
 	return nil
 }
 
-type Subscriber struct {
-	Subscription webpush.Subscription
-	Email        string
-}
-
+// DeleteNotificationsHandler clears all notification rows for the caller. The
+// dropdown's "Clear all" button now uses PUT /api/notification/read-all
+// instead, which preserves history; this endpoint stays for completeness
+// (e.g. account-wipe flows).
 func DeleteNotificationsHandler(c *gin.Context) {
 	email, _ := c.Get("email")
-
-	if database.DeleteNotifications(email.(string)) != nil {
+	if err := database.DeleteNotifications(email.(string)); err != nil {
+		log.Printf("notifications: delete for %q: %v", email, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "error fetching notifications"})
 		return
 	}
+	c.JSON(http.StatusOK, gin.H{"message": "notifications deleted"})
+}
 
-	c.JSON(http.StatusOK, gin.H{"error": "invalid time format"})
+// MarkAllReadHandler flips IsRead on every unread row for the caller in one
+// SQL UPDATE, replacing the old "delete to clear the badge" hack.
+func MarkAllReadHandler(c *gin.Context) {
+	email, _ := c.Get("email")
+	if err := database.MarkAllNotificationsRead(email.(string)); err != nil {
+		log.Printf("notifications: mark-all-read for %q: %v", email, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "could not mark notifications read"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "marked read"})
 }
 
 func GetNotificationPublicKey(c *gin.Context) {
 	publicKey, err := database.GetVAAPIpublicKey()
 	if err != nil {
+		log.Printf("notifications: get public key: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "error fetching vaapi public key"})
 		return
 	}
-
 	c.JSON(http.StatusOK, publicKey)
 }
 
 func GetNotificationsHandler(c *gin.Context) {
 	email, _ := c.Get("email")
-
-	notifications, err := database.GetNotifications(email.(string))
-
+	notifications, err := database.GetNotifications(email.(string), 50)
 	if err != nil {
+		log.Printf("notifications: get for %q: %v", email, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "error fetching notifications"})
 		return
 	}
-
-	notifications = []models.Notification{}
-
 	c.JSON(http.StatusOK, notifications)
 }
 
+// MarkNotificationReadHandler now takes the row id rather than the RFC3339
+// timestamp. The old timestamp-based lookup round-tripped through time.Parse
+// and was unstable across precision boundaries; ids are the natural key.
 func MarkNotificationReadHandler(c *gin.Context) {
 	email, exists := c.Get("email")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
 		return
 	}
-
-	// Parse the "time" parameter
-	timeParam := c.Param("time")
-	notificationTime, err := time.Parse(time.RFC3339, timeParam) // Assuming RFC3339 format for the timestamp
+	idParam := c.Param("id")
+	id, err := strconv.ParseUint(idParam, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid time format"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid notification id"})
 		return
 	}
-
-	// Mark the notification as read
-	err = database.MarkNotificationAsRead(email.(string), notificationTime)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "error marking notification as read"})
+	if err := database.MarkNotificationAsRead(email.(string), uint(id)); err != nil {
+		// Surface 404 rather than leaking ownership info — matches the
+		// project-wide policy of not returning 500 for normal misses.
+		log.Printf("notifications: mark read id=%d email=%q: %v", id, email, err)
+		c.JSON(http.StatusNotFound, gin.H{"error": "notification not found"})
 		return
 	}
-
 	c.JSON(http.StatusOK, gin.H{"message": "notification marked as read"})
 }
 
+// SubscribeNotification accepts a PushSubscription JSON and binds the device
+// to the current user. The actual take-over (rebinding the endpoint away from
+// any previous owner on the same browser) happens inside
+// database.UpsertSubscriber.
 func SubscribeNotification(c *gin.Context) {
 	email, _ := c.Get("email")
 	var sub webpush.Subscription
@@ -148,31 +165,70 @@ func SubscribeNotification(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request"})
 		return
 	}
-
-	jsonSub, err := json.Marshal(&sub)
-	if err != nil {
-		log.Printf("Error marshalling sub %v", err)
+	userAgent := c.GetHeader("User-Agent")
+	if err := database.UpsertSubscriber(email.(string), sub, userAgent); err != nil {
+		log.Printf("notifications: upsert subscriber for %q: %v", email, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "could not register subscription"})
 		return
 	}
-
-	if database.AppendSubscriber(email.(string), jsonSub) != nil {
-		log.Printf("Error appending subscriber %v", err)
-		return
-	}
-
 	c.JSON(http.StatusCreated, gin.H{"status": "created"})
 }
 
-func ResetNotifications(c *gin.Context) {
-	err := database.ResetNotifications()
+// UnsubscribeNotification removes one device's subscription. The frontend
+// calls this from the explicit "disable notifications" button — *not* on
+// logout. Logout intentionally leaves the row in place so the user keeps
+// receiving pushes after signing out, which is the chosen behaviour.
+func UnsubscribeNotification(c *gin.Context) {
+	email, _ := c.Get("email")
+	var body struct {
+		Endpoint string `json:"endpoint"`
+	}
+	if err := c.BindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request"})
+		return
+	}
+	if err := database.DeleteSubscriberByEndpoint(email.(string), body.Endpoint); err != nil {
+		log.Printf("notifications: delete subscriber for %q: %v", email, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "could not remove subscription"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "removed"})
+}
+
+// ListDevices returns the caller's push subscriptions for a future "your
+// devices" management UI. Endpoints are hashed because the raw value is a
+// secret URL that lets anyone push to that device.
+func ListDevices(c *gin.Context) {
+	email, _ := c.Get("email")
+	rows, err := database.ListSubscribersForEmail(email.(string))
 	if err != nil {
+		log.Printf("notifications: list devices for %q: %v", email, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "could not list devices"})
+		return
+	}
+	out := make([]gin.H, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, gin.H{
+			"endpointHash": hashEndpoint(r.Endpoint),
+			"userAgent":    r.UserAgent,
+			"lastSeenAt":   r.LastSeenAt,
+		})
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func hashEndpoint(endpoint string) string {
+	sum := sha256.Sum256([]byte(endpoint))
+	return hex.EncodeToString(sum[:8])
+}
+
+func ResetNotifications(c *gin.Context) {
+	if err := database.ResetNotifications(); err != nil {
 		log.Printf("Unable to reset VAAPI keys %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Unable to perform requested task"})
 		return
 	}
-
-	err = createAndPersistVAAPIKeys()
-	if err != nil {
+	if err := createAndPersistVAAPIKeys(); err != nil {
 		log.Printf("Unable to persist VAAPI keys %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Unable to perform requested task"})
 		return
@@ -180,106 +236,193 @@ func ResetNotifications(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"success": "VAAPI keys reseted and created"})
 }
 
-func SendMessage(title, body, url, foundBy, ignoreEmail string, usersToNotify map[string]bool) error {
-	// Placeholder for the logic to find subscribers who have read access to the resource
-	//subscribers := findSubscribersWithReadAccess(url)
+// DispatchRequest is the new entry point the event queue hands to the
+// dispatcher. Replaces SendMessage's positional-arg soup and makes the
+// distinction between "actor" (skipped from delivery, recorded as Who) and
+// recipients explicit.
+type DispatchRequest struct {
+	Kind            string
+	VulnerabilityID uint
+	ActorEmail      string
+	Recipients      []string
+	Title           string
+	Body            string
+	URL             string
+}
 
-	// Map to keep track of the subscribers who have already received the notification
-	sentTo := make(map[string]bool)
+// pushSender is the function Dispatch uses to deliver one push. The real
+// implementation in sendPush talks to a webpush provider over HTTPS; tests
+// swap this for an in-memory recorder so they can assert delivery shape
+// without standing up VAPID + a fake provider.
+var pushSender = sendPush
 
-	subscribers, err := database.GetAllSubscribers()
-	if err != nil {
-		return err
+// Dispatch is the single fan-out point for both push and in-app delivery. It:
+//   - normalises and dedupes the recipient list (trim/lowercase)
+//   - drops the actor and any recipient whose access has been revoked
+//   - honours the per-user prefs matrix for each channel
+//   - inserts one notifications row per surviving recipient (race-free single
+//     INSERT — no read-modify-write)
+//   - pushes to every endpoint the recipient has registered (no `break` on
+//     first match like the old code)
+//   - cleans up dead endpoints (404/410) so the table can't grow stale
+//
+// Push and in-app errors are logged and skipped per-recipient; one bad device
+// no longer halts delivery to the rest of the list.
+func Dispatch(req DispatchRequest) error {
+	recipients := normaliseRecipients(req.Recipients, req.ActorEmail)
+	if len(recipients) == 0 {
+		return nil
 	}
 
-	// notification each subscriber in PRISM
-	for userEmail := range usersToNotify {
-		// Skip if the subscriber is the one who registered the vulnerability
-		if userEmail == ignoreEmail {
+	subs, err := database.ListSubscribersForEmails(recipients)
+	if err != nil {
+		log.Printf("notifications: list subscribers: %v", err)
+		subs = nil // Continue with in-app delivery even if push lookup fails.
+	}
+	subsByEmail := map[string][]database.Subscriber{}
+	for _, s := range subs {
+		s := s
+		subsByEmail[s.Email] = append(subsByEmail[s.Email], s)
+	}
+
+	pushPayload, err := json.Marshal(&PushMessage{
+		Title: req.Title,
+		Body:  req.Body,
+		Url:   req.URL,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal push payload: %w", err)
+	}
+
+	vulnID := req.VulnerabilityID
+	var vulnIDPtr *uint
+	if vulnID != 0 {
+		v := vulnID
+		vulnIDPtr = &v
+	}
+
+	for _, recipient := range recipients {
+		canSee := true
+		if vulnID != 0 {
+			ok, err := database.CanRecipientSeeVulnerability(recipient, vulnID)
+			if err != nil {
+				log.Printf("notifications: acl check for %q: %v", recipient, err)
+				continue
+			}
+			canSee = ok
+		}
+		if !canSee {
 			continue
 		}
 
-		// Web push notification to each subscriber
-		for _, s := range subscribers {
-			if s.Email == userEmail {
-				err = sendPushNotification(s.Subscription, title, body, url)
-				if err != nil {
-					return err
-				}
+		prefs, err := loadPrefs(recipient)
+		if err != nil {
+			log.Printf("notifications: load prefs for %q: %v", recipient, err)
+			prefs = models.NotificationPrefs{}.Effective()
+		}
 
-				break
+		if inAppEnabled(prefs, req.Kind) {
+			if err := database.CreateNotification(recipient, models.Notification{
+				Kind:            req.Kind,
+				Who:             req.ActorEmail,
+				What:            req.Body,
+				Where:           req.URL,
+				VulnerabilityID: vulnIDPtr,
+			}); err != nil {
+				log.Printf("notifications: create in-app for %q: %v", recipient, err)
 			}
 		}
 
-		// Skip if the subscriber has already been sent this notification
-		if _, alreadySent := sentTo[userEmail]; alreadySent {
+		if !pushEnabled(prefs, req.Kind) {
 			continue
 		}
-
-		// Create the notification object
-		notification := models.Notification{
-			Who:    ignoreEmail,
-			What:   body,
-			IsRead: false,
-			Where:  url,
-			When:   time.Now(),
+		for _, s := range subsByEmail[recipient] {
+			s := s
+			if err := pushSender(s, pushPayload); err != nil {
+				log.Printf("notifications: push to %q (endpoint %s): %v",
+					recipient, hashEndpoint(s.Endpoint), err)
+			}
 		}
-
-		// Save the notification to the database
-		err := database.CreateNotification(userEmail, notification)
-		if err != nil {
-			log.Printf("Error creating notification for %s: %v", userEmail, err)
-			return err
-		}
-
-		// Mark this subscriber as having been sent the notification
-		sentTo[userEmail] = true
 	}
 	return nil
 }
 
-func sendPushNotification(subscriptionJson []byte, title, body, url string) error {
-	// Construct your push notification payload by marshaling your data structure to JSON
-	data := &PushMessage{
-		Title: title,
-		Body:  body,
-		Url:   url,
+func inAppEnabled(p models.ResolvedNotificationPrefs, kind string) bool {
+	switch kind {
+	case models.NotificationKindNewVuln:
+		return p.InAppNewVuln
+	case models.NotificationKindNewComment:
+		return p.InAppNewComment
+	default:
+		return true
 	}
-	jsonPayload, err := json.Marshal(data)
+}
+
+func pushEnabled(p models.ResolvedNotificationPrefs, kind string) bool {
+	switch kind {
+	case models.NotificationKindNewVuln:
+		return p.PushNewVuln
+	case models.NotificationKindNewComment:
+		return p.PushNewComment
+	default:
+		return true
+	}
+}
+
+func loadPrefs(email string) (models.ResolvedNotificationPrefs, error) {
+	settings, err := database.GetPreferencesForUser(email)
 	if err != nil {
-		log.Print(http.StatusInternalServerError, gin.H{"error": "Error marshaling push notification payload"})
-		return err
+		return models.NotificationPrefs{}.Effective(), err
 	}
-	var subscription webpush.Subscription
+	return settings.NotificationPrefs.Effective(), nil
+}
 
-	if err := json.Unmarshal(subscriptionJson, &subscription); err != nil {
-		log.Printf("Error unmarshalling subscribers %v", err)
-		return err
+// normaliseRecipients trims whitespace, lowercases, drops the actor, and
+// dedupes. The dispatcher always uses the canonical lowercased form so push
+// lookups and ACL checks agree on identity.
+func normaliseRecipients(in []string, actor string) []string {
+	actor = strings.ToLower(strings.TrimSpace(actor))
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		e := strings.ToLower(strings.TrimSpace(raw))
+		if e == "" || e == actor {
+			continue
+		}
+		if _, dup := seen[e]; dup {
+			continue
+		}
+		seen[e] = struct{}{}
+		out = append(out, e)
 	}
+	return out
+}
 
-	resp, err := webpush.SendNotification(jsonPayload, &subscription, &webpush.Options{
+// sendPush dispatches one push and reaps dead endpoints. Returning nil for
+// 404/410 lets the caller continue down the recipient list — the row is gone
+// from the next dispatch onward.
+func sendPush(s database.Subscriber, payload []byte) error {
+	sub := s.AsPushSubscription()
+	resp, err := webpush.SendNotification(payload, &sub, &webpush.Options{
 		Subscriber:      "cat@nhn.no",
 		VAPIDPublicKey:  vapidPublicKey,
 		VAPIDPrivateKey: vapidPrivateKey,
 		TTL:             30,
 	})
 	if err != nil {
-		// Handle error
-		log.Printf("Error sending web push %v", err)
 		return err
 	}
-	if resp.StatusCode != 200 && resp.StatusCode != 202 {
-		// Read response body for additional error details
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Error reading response body: %v", err)
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		if delErr := database.DeleteDeadSubscriber(s.Endpoint); delErr != nil {
+			log.Printf("notifications: prune dead endpoint %s: %v",
+				hashEndpoint(s.Endpoint), delErr)
 		}
-		bodyString := string(bodyBytes)
-
-		// Log detailed error message
-		log.Printf("Error sending web push. Status Code: %d, Status: %s, Response Body: %s",
-			resp.StatusCode, resp.Status, bodyString)
+		return nil
 	}
-	defer resp.Body.Close() // Close the response body when done reading
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		return errors.New("push provider returned " + resp.Status + ": " + string(body))
+	}
 	return nil
 }

--- a/api/routes/notification.go
+++ b/api/routes/notification.go
@@ -157,7 +157,9 @@ func MarkNotificationReadHandler(c *gin.Context) {
 // SubscribeNotification accepts a PushSubscription JSON and binds the device
 // to the current user. The actual take-over (rebinding the endpoint away from
 // any previous owner on the same browser) happens inside
-// database.UpsertSubscriber.
+// database.UpsertSubscriber, and is gated on the caller presenting the same
+// p256dh/auth keys as the existing row — so a third party who only knows the
+// endpoint URL can't yank somebody else's subscription.
 func SubscribeNotification(c *gin.Context) {
 	email, _ := c.Get("email")
 	var sub webpush.Subscription
@@ -167,6 +169,15 @@ func SubscribeNotification(c *gin.Context) {
 	}
 	userAgent := c.GetHeader("User-Agent")
 	if err := database.UpsertSubscriber(email.(string), sub, userAgent); err != nil {
+		if errors.Is(err, database.ErrSubscriberEndpointClaimed) {
+			// 409 distinguishes "endpoint is already someone else's" from a
+			// generic validation failure. The body stays opaque so we don't
+			// confirm the existence of any particular endpoint to a probing
+			// attacker.
+			log.Printf("notifications: take-over rejected for %q (endpoint claimed)", email)
+			c.JSON(http.StatusConflict, gin.H{"error": "endpoint already registered"})
+			return
+		}
 		log.Printf("notifications: upsert subscriber for %q: %v", email, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "could not register subscription"})
 		return

--- a/api/routes/notification_test.go
+++ b/api/routes/notification_test.go
@@ -1,0 +1,363 @@
+package routes
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"prism/database"
+	"prism/models"
+
+	"github.com/SherClockHolmes/webpush-go"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// dispatchTestDBCounter — see comment in database/subscribers_test.go.
+var dispatchTestDBCounter uint64
+
+// --- pure-function tests (no DB) ---
+
+func TestNormaliseRecipients_TrimsLowercasesAndDedupes(t *testing.T) {
+	got := normaliseRecipients(
+		[]string{"  Alice@x ", "alice@x", "BOB@x", "", "  ", "carol@x"},
+		"",
+	)
+	sort.Strings(got)
+	want := []string{"alice@x", "bob@x", "carol@x"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalise = %v, want %v", got, want)
+	}
+}
+
+func TestNormaliseRecipients_DropsActor(t *testing.T) {
+	got := normaliseRecipients(
+		[]string{"alice@x", "bob@x", "Alice@X"},
+		"  Alice@x  ",
+	)
+	if !reflect.DeepEqual(got, []string{"bob@x"}) {
+		t.Fatalf("normalise = %v, want only bob", got)
+	}
+}
+
+func TestInAppPushEnabled_HonourPrefs(t *testing.T) {
+	off := false
+	prefs := models.NotificationPrefs{
+		InAppNewVuln:    &off,
+		PushNewComment:  &off,
+		InAppNewComment: nil,
+		PushNewVuln:     nil,
+	}.Effective()
+
+	if inAppEnabled(prefs, models.NotificationKindNewVuln) {
+		t.Fatalf("in-app new-vuln should be off")
+	}
+	if !inAppEnabled(prefs, models.NotificationKindNewComment) {
+		t.Fatalf("in-app new-comment defaults to on")
+	}
+	if !pushEnabled(prefs, models.NotificationKindNewVuln) {
+		t.Fatalf("push new-vuln defaults to on")
+	}
+	if pushEnabled(prefs, models.NotificationKindNewComment) {
+		t.Fatalf("push new-comment should be off")
+	}
+}
+
+func TestHashEndpoint_DeterministicAndShort(t *testing.T) {
+	a := hashEndpoint("https://push.example/abc")
+	b := hashEndpoint("https://push.example/abc")
+	c := hashEndpoint("https://push.example/xyz")
+	if a != b {
+		t.Fatalf("hash should be deterministic")
+	}
+	if a == c {
+		t.Fatalf("different endpoints should hash differently")
+	}
+	if len(a) != 16 {
+		t.Fatalf("expected 16-char hex prefix, got %d", len(a))
+	}
+}
+
+// --- Dispatch integration test (uses in-memory db + mocked push sender) ---
+
+// recordedPush is what the test push sender captures so the test can assert
+// "this email's endpoint got a payload" without standing up VAPID + a fake
+// provider.
+type recordedPush struct {
+	Endpoint string
+	Payload  string
+}
+
+func setupDispatchTestDB(t *testing.T) func() {
+	t.Helper()
+	dsn := fmt.Sprintf("file:dispatch_test_%d?mode=memory&cache=shared",
+		atomic.AddUint64(&dispatchTestDBCounter, 1))
+	testDB, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Same MaxOpenConns(1) trick as the database package tests — SQLite
+	// in-memory shared-cache is single-writer and GORM otherwise opens
+	// multiple connections, causing spurious SQLITE_BUSY.
+	if sqlDB, err := testDB.DB(); err != nil {
+		t.Fatalf("sql.DB: %v", err)
+	} else {
+		sqlDB.SetMaxOpenConns(1)
+	}
+	if err := testDB.Exec("PRAGMA busy_timeout = 5000;").Error; err != nil {
+		t.Fatalf("busy_timeout: %v", err)
+	}
+	if err := testDB.AutoMigrate(
+		&database.Subscriber{},
+		&database.Notification{},
+		&database.UserData{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	original := database.SetDBForTest(testDB)
+	if _, err := database.MigrateNotifications(); err != nil {
+		t.Fatalf("migrate notif: %v", err)
+	}
+	return func() { database.SetDBForTest(original) }
+}
+
+func TestDispatch_SkipsActorAndDeliversToOthers(t *testing.T) {
+	defer setupDispatchTestDB(t)()
+
+	if err := database.UpsertSubscriber("alice@x", webpush.Subscription{
+		Endpoint: "https://push/alice",
+		Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+	}, ""); err != nil {
+		t.Fatalf("alice subscribe: %v", err)
+	}
+	if err := database.UpsertSubscriber("bob@x", webpush.Subscription{
+		Endpoint: "https://push/bob",
+		Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+	}, ""); err != nil {
+		t.Fatalf("bob subscribe: %v", err)
+	}
+
+	var recorded []recordedPush
+	var mu sync.Mutex
+	original := pushSender
+	pushSender = func(s database.Subscriber, payload []byte) error {
+		mu.Lock()
+		defer mu.Unlock()
+		recorded = append(recorded, recordedPush{
+			Endpoint: s.Endpoint,
+			Payload:  string(payload),
+		})
+		return nil
+	}
+	defer func() { pushSender = original }()
+
+	if err := Dispatch(DispatchRequest{
+		Kind:       models.NotificationKindNewVuln,
+		ActorEmail: "alice@x",
+		Recipients: []string{"alice@x", "bob@x"},
+		Title:      "Test",
+		Body:       "hello",
+		URL:        "/vulnerability/1/view",
+		// VulnerabilityID intentionally 0 to skip the ACL hop — the ACL
+		// path is exercised separately in TestDispatch_FiltersByACL.
+	}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	// Bob received a push, Alice did not (she's the actor).
+	if len(recorded) != 1 || recorded[0].Endpoint != "https://push/bob" {
+		t.Fatalf("expected one push to bob's endpoint, got %+v", recorded)
+	}
+	// Bob has an in-app row, Alice does not.
+	bobRows, _ := database.GetNotifications("bob@x", 10)
+	aliceRows, _ := database.GetNotifications("alice@x", 10)
+	if len(bobRows) != 1 {
+		t.Fatalf("bob should have 1 in-app row, got %d", len(bobRows))
+	}
+	if bobRows[0].Who != "alice@x" || bobRows[0].What != "hello" {
+		t.Fatalf("in-app row content wrong: %+v", bobRows[0])
+	}
+	if len(aliceRows) != 0 {
+		t.Fatalf("actor should not receive their own notification, got %d", len(aliceRows))
+	}
+}
+
+func TestDispatch_HonoursInAppOptOut(t *testing.T) {
+	defer setupDispatchTestDB(t)()
+
+	// Bob exists with an opted-out in-app pref for new comments.
+	active := true
+	if err := database.DBForTest().Create(&database.UserData{
+		Email:  "bob@x",
+		Role:   "visitor",
+		Active: &active,
+	}).Error; err != nil {
+		t.Fatalf("seed bob: %v", err)
+	}
+	off := false
+	if err := database.PatchSettingsForUser("bob@x", models.UserSettings{
+		NotificationPrefs: models.NotificationPrefs{InAppNewComment: &off},
+	}); err != nil {
+		t.Fatalf("patch prefs: %v", err)
+	}
+
+	original := pushSender
+	pushSender = func(database.Subscriber, []byte) error { return nil }
+	defer func() { pushSender = original }()
+
+	if err := Dispatch(DispatchRequest{
+		Kind:       models.NotificationKindNewComment,
+		ActorEmail: "alice@x",
+		Recipients: []string{"bob@x"},
+		Title:      "PRISM",
+		Body:       "💬 hi",
+		URL:        "/vulnerability/1/view#cid",
+	}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	rows, _ := database.GetNotifications("bob@x", 10)
+	if len(rows) != 0 {
+		t.Fatalf("bob opted out of in-app for comments; expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestDispatch_HonoursPushOptOut(t *testing.T) {
+	defer setupDispatchTestDB(t)()
+
+	active := true
+	if err := database.DBForTest().Create(&database.UserData{
+		Email:  "bob@x",
+		Role:   "visitor",
+		Active: &active,
+	}).Error; err != nil {
+		t.Fatalf("seed bob: %v", err)
+	}
+	off := false
+	if err := database.PatchSettingsForUser("bob@x", models.UserSettings{
+		NotificationPrefs: models.NotificationPrefs{PushNewVuln: &off},
+	}); err != nil {
+		t.Fatalf("patch prefs: %v", err)
+	}
+	if err := database.UpsertSubscriber("bob@x", webpush.Subscription{
+		Endpoint: "https://push/bob",
+		Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+	}, ""); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	pushed := 0
+	original := pushSender
+	pushSender = func(database.Subscriber, []byte) error { pushed++; return nil }
+	defer func() { pushSender = original }()
+
+	if err := Dispatch(DispatchRequest{
+		Kind:       models.NotificationKindNewVuln,
+		ActorEmail: "alice@x",
+		Recipients: []string{"bob@x"},
+		Title:      "Project",
+		Body:       "New vuln Foo",
+		URL:        "/vulnerability/9/view",
+	}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if pushed != 0 {
+		t.Fatalf("bob opted out of push; expected 0 sends, got %d", pushed)
+	}
+	// In-app still landed (in-app default is on).
+	rows, _ := database.GetNotifications("bob@x", 10)
+	if len(rows) != 1 {
+		t.Fatalf("expected in-app to still fire when only push is off, got %d", len(rows))
+	}
+}
+
+func TestDispatch_PushesToAllEndpointsForOneUser(t *testing.T) {
+	defer setupDispatchTestDB(t)()
+
+	for _, ep := range []string{"https://push/bob-laptop", "https://push/bob-phone"} {
+		if err := database.UpsertSubscriber("bob@x", webpush.Subscription{
+			Endpoint: ep,
+			Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+		}, ""); err != nil {
+			t.Fatalf("subscribe %s: %v", ep, err)
+		}
+	}
+
+	var recorded []string
+	var mu sync.Mutex
+	original := pushSender
+	pushSender = func(s database.Subscriber, _ []byte) error {
+		mu.Lock()
+		recorded = append(recorded, s.Endpoint)
+		mu.Unlock()
+		return nil
+	}
+	defer func() { pushSender = original }()
+
+	if err := Dispatch(DispatchRequest{
+		Kind:       models.NotificationKindNewVuln,
+		ActorEmail: "alice@x",
+		Recipients: []string{"bob@x"},
+		Title:      "T",
+		Body:       "B",
+		URL:        "/x",
+	}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	sort.Strings(recorded)
+	want := []string{"https://push/bob-laptop", "https://push/bob-phone"}
+	if !reflect.DeepEqual(recorded, want) {
+		t.Fatalf("expected push to both devices, got %v", recorded)
+	}
+}
+
+func TestDispatch_ContinuesAfterPushError(t *testing.T) {
+	defer setupDispatchTestDB(t)()
+
+	if err := database.UpsertSubscriber("bob@x", webpush.Subscription{
+		Endpoint: "https://push/broken",
+		Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+	}, ""); err != nil {
+		t.Fatalf("subscribe bob: %v", err)
+	}
+	if err := database.UpsertSubscriber("carol@x", webpush.Subscription{
+		Endpoint: "https://push/ok",
+		Keys:     webpush.Keys{P256dh: "p", Auth: "a"},
+	}, ""); err != nil {
+		t.Fatalf("subscribe carol: %v", err)
+	}
+
+	carolGotPushed := false
+	original := pushSender
+	pushSender = func(s database.Subscriber, _ []byte) error {
+		if s.Endpoint == "https://push/broken" {
+			return errInjected{}
+		}
+		if s.Endpoint == "https://push/ok" {
+			carolGotPushed = true
+		}
+		return nil
+	}
+	defer func() { pushSender = original }()
+
+	if err := Dispatch(DispatchRequest{
+		Kind:       models.NotificationKindNewVuln,
+		ActorEmail: "alice@x",
+		Recipients: []string{"bob@x", "carol@x"},
+		Title:      "T",
+		Body:       "B",
+		URL:        "/x",
+	}); err != nil {
+		t.Fatalf("dispatch should not bubble per-recipient push errors, got %v", err)
+	}
+	if !carolGotPushed {
+		t.Fatalf("carol should have been pushed even though bob's send failed")
+	}
+}
+
+type errInjected struct{}
+
+func (errInjected) Error() string { return "injected" }

--- a/web/src/lib/components/Notifications/NotificationButton.svelte
+++ b/web/src/lib/components/Notifications/NotificationButton.svelte
@@ -1,8 +1,7 @@
 <!-- NotificationButton.svelte -->
 <script>
-	import { goto } from "$app/navigation";
-	import { Fetch } from "$lib/fetchUtil";
-	import { onMount } from "svelte";
+  import { Fetch } from "$lib/fetchUtil";
+  import { onMount } from "svelte";
   import { createEventDispatcher } from 'svelte';
 
   /**
@@ -13,65 +12,104 @@
   /** @type {Props} */
   let { notificationPermission = $bindable('default') } = $props();
   const dispatch = createEventDispatcher();
-  let applicationServerKey = ""
+
+  // Cached VAPID public key. Stored in localStorage keyed on origin so the
+  // round trip to /api/notification/publicKey only happens once per browser
+  // per server, and is mirrored into a SW-readable Cache entry so the
+  // pushsubscriptionchange handler can re-subscribe without contacting the
+  // page.
+  const VAPID_CACHE_KEY = `prism:vapidPublicKey:${window.location.origin}`;
+  let applicationServerKey = "";
 
   function updatePermission(newPermission) {
     notificationPermission = newPermission;
     dispatch('permissionChange', { notificationPermission });
   }
 
+  async function ensureVapidKey() {
+    if (applicationServerKey) return applicationServerKey;
+    const cached = localStorage.getItem(VAPID_CACHE_KEY);
+    if (cached) {
+      applicationServerKey = cached;
+    } else {
+      applicationServerKey = await Fetch(`/api/notification/publicKey`);
+      if (applicationServerKey) {
+        localStorage.setItem(VAPID_CACHE_KEY, applicationServerKey);
+      }
+    }
+    // Mirror into the cache so service-worker.js can read it without
+    // touching the network when handling pushsubscriptionchange.
+    if (applicationServerKey && 'caches' in window) {
+      try {
+        const cache = await caches.open('prism-notifications');
+        await cache.put('/__vapid', new Response(applicationServerKey));
+      } catch (_) { /* non-fatal */ }
+    }
+    return applicationServerKey;
+  }
+
   function askNotificationPermission() {
-    // Check if the browser supports notifications
     if (!("Notification" in window)) {
       console.log("This browser does not support notifications.");
       return;
     }
-
-    if(notificationPermission === 'granted'){return}
-
+    if (notificationPermission === 'granted') {
+      // Already granted — re-affirm with the server in case the row was
+      // dropped (dead-endpoint cleanup, ResetNotifications, etc).
+      reaffirmSubscription();
+      return;
+    }
     Notification.requestPermission().then((permission) => {
-      if(permission === "granted") {
+      if (permission === "granted") {
         subscribeUserToPush();
       }
       updatePermission(permission);
     });
   }
 
-  onMount(async() => {
-    // Check the current permission status when the component is mounted
+  onMount(async () => {
     if ('Notification' in window) {
       notificationPermission = Notification.permission;
       updatePermission(notificationPermission);
     }
-    applicationServerKey = await Fetch(`/api/notification/publicKey`);
+    await ensureVapidKey();
+    if (notificationPermission === 'granted') {
+      // Reattach to whatever the browser already has so we don't churn
+      // server rows on every page mount. UpsertSubscriber is idempotent
+      // for the (email, endpoint) pair so this is cheap.
+      await reaffirmSubscription();
+    }
   });
+
+  async function reaffirmSubscription() {
+    const registration = await navigator.serviceWorker.ready;
+    let subscription = await registration.pushManager.getSubscription();
+    if (!subscription) {
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: await ensureVapidKey()
+      });
+    }
+    await Fetch("/api/notification/subscribe", {
+      method: "POST",
+      body: JSON.stringify(subscription),
+    });
+  }
 
   async function subscribeUserToPush() {
-  const registration = await navigator.serviceWorker.ready;
-  const subscription = await registration.pushManager.subscribe({
-    userVisibleOnly: true,
-    // You may need to generate a suitable application server key
-    // This could be a VAPID key for instance
-    applicationServerKey: applicationServerKey
-  });
-
-  // Send the subscription to the Go server
-  await Fetch("/api/notification/subscribe", {
-    method: "POST",
-    body: JSON.stringify(subscription),
-  });
-}
+    const registration = await navigator.serviceWorker.ready;
+    let subscription = await registration.pushManager.getSubscription();
+    if (!subscription) {
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: await ensureVapidKey()
+      });
+    }
+    await Fetch("/api/notification/subscribe", {
+      method: "POST",
+      body: JSON.stringify(subscription),
+    });
+  }
 </script>
 
 <button class="btn btn-primary btn-pill w-70" onclick={askNotificationPermission}>Enable</button>
-
-<!-- <div>
-  <label class="row">
-    <span class="col">Push Notifications</span>
-    <span class="col-auto">
-      <label class="form-check form-check-single form-switch">
-        <input class="form-check-input" type="checkbox" on:click={askNotificationPermission} checked="{notificationPermission === 'granted'}" disabled="{notificationPermission === 'granted'}">
-      </label>
-    </span>
-  </label>
-</div> -->

--- a/web/src/lib/components/Notifications/NotificationDropdown.svelte
+++ b/web/src/lib/components/Notifications/NotificationDropdown.svelte
@@ -14,6 +14,7 @@
 /**
  * Notification structure as received from server.
  * @typedef {Object} Notification
+ * @property {number} id - Unique row id used for mark-as-read.
  * @property {string} who - The identifier of the user who triggered the notification.
  * @property {string} what - A description of the notification event.
  * @property {boolean} read - Whether the notification has been read.
@@ -31,31 +32,66 @@
   let { notifications = $bindable([]) } = $props();
   let notificationPermission = $state("default");
 
+  // Cursor used by the toast diff: anything strictly newer than this on a
+  // subsequent poll fires a toast. Initialised to the most recent timestamp
+  // already in the list when the component mounts, so we don't spam toasts
+  // for backlog the user already saw.
+  /** @type {string | null} */
+  let lastSeenWhen = $state(null);
+  let primed = $state(false);
 
-  // Function to sort notifications by 'when' in descending order
-  function sortNotifications() {
-    /** @type {Notification[]} */
-    const newNotifications = notifications.filter(notification =>
-      !notifications.some(existing => existing.when === notification.when)
+  /**
+   * @param {string | null} acc
+   * @param {Notification} n
+   * @returns {string | null}
+   */
+  function pickNewer(acc, n) {
+    if (!n.when) return acc;
+    if (!acc) return n.when;
+    return new Date(n.when) > new Date(acc) ? n.when : acc;
+  }
+
+  function renderToasts() {
+    if (!Array.isArray(notifications)) return;
+    if (!primed) {
+      /** @type {string | null} */
+      let max = null;
+      for (const n of notifications) max = pickNewer(max, n);
+      lastSeenWhen = max;
+      primed = true;
+      return;
+    }
+    const fresh = notifications.filter(n =>
+      n.read === false &&
+      (lastSeenWhen === null || new Date(n.when) > new Date(lastSeenWhen))
     );
-
-    // Display toasts for new notifications
-    newNotifications.forEach(async newNotification => {
-      if(newNotification.read == false){
+    if (fresh.length === 0) return;
+    fresh.forEach(async newNotification => {
+      let label = newNotification.who;
+      try {
         const userData = await Fetch(`/api/profile/${newNotification.who}`);
-        toast.info(`${userData.name}- ${newNotification.what}`, {
-                  action: {
-                    label: 'Show',
-                    onClick: () => openAction(newNotification)
-                  }
-                });
-      }
+        if (userData?.name) label = userData.name;
+      } catch (_) { /* fall back to the raw identifier */ }
+      toast.info(`${label} — ${newNotification.what}`, {
+        action: {
+          label: 'Show',
+          onClick: () => openAction(newNotification)
+        }
+      });
     });
+    /** @type {string | null} */
+    let max = lastSeenWhen;
+    for (const n of fresh) max = pickNewer(max, n);
+    lastSeenWhen = max;
+  }
+
+  function sortNotifications() {
     notifications = notifications.sort((a, b) => new Date(b.when) - new Date(a.when));
   }
 
   onMount(async () => {
-    await sortNotifications()
+    sortNotifications();
+    renderToasts();
     if ('Notification' in window) {
       notificationPermission = Notification.permission;
     }
@@ -86,30 +122,33 @@
       }
   });
 
+  onDestroy(() => unsubscribe());
+
   function handlePermissionChange(event) {
     notificationPermission = event.detail.notificationPermission;
   }
 
   async function openAction(notification){
-    await Fetch("/api/notification/" + notification.when + "/read", {
-      method:"PUT"
-    });
+    await Fetch(`/api/notification/${notification.id}/read`, { method: "PUT" });
     notification.read = true;
-    window.location.href = notification.where; //@todo force redirect, fix
-    await goto(notification.where)
+    // The server only stores paths in `where` so navigating to it can't
+    // redirect off-site.
+    await goto(notification.where);
     closeDropdown();
   }
 
   async function markAllRead() {
-    await Fetch("/api/notification", {method: "DELETE"});
-    notifications = []
-    setTimeout(() => {
-      closeDropdown();
-    }, 1000);
+    // Switched from DELETE /api/notification to PUT /api/notification/read-all
+    // so clearing the badge no longer destroys history.
+    await Fetch("/api/notification/read-all", { method: "PUT" });
+    notifications = notifications.map(n => ({ ...n, read: true }));
+    setTimeout(closeDropdown, 1000);
   }
+
   run(() => {
     if (notifications) {
-      sortNotifications()
+      sortNotifications();
+      renderToasts();
     }
   });
 </script>
@@ -150,7 +189,6 @@
     transition:slide
 >
 
-  <!-- <div class="dropdown-divider"></div> -->
   {#if notificationPermission == 'granted'}
   {#if notifications?.length > 0}
     <div class=" pl-3 pr-3 pt-1">
@@ -159,14 +197,14 @@
         <label class="form-label text-azure">Notifications</label>
       </div>
       <div class="col-auto">
-        <a href="#" onclick={markAllRead}>Clear all</a>
+        <a href="#" onclick={markAllRead}>Mark all read</a>
       </div>
       </div>
     </div>
   {/if}
   <div class="d-flex justify-content-center flex-wrap">
     {#if notifications?.length > 0}
-        {#each notifications as notification}
+        {#each notifications as notification (notification.id)}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div class="dropdown-item w-100 cursor-pointer" class:bg-secondary-lt={notification.read == false} onclick={() => openAction(notification)} >

--- a/web/src/lib/components/settings/notificationPrefs.svelte
+++ b/web/src/lib/components/settings/notificationPrefs.svelte
@@ -1,0 +1,118 @@
+<script>
+  // Per-user opt-out matrix for the two channels (in-app dropdown, web-push)
+  // crossed with the two event kinds the dispatcher emits (new vulnerability,
+  // new comment). The server treats unset === true, so a never-touched user
+  // gets everything. Toggling here writes the explicit boolean.
+  import { onMount } from 'svelte';
+  import { Fetch } from '$lib/fetchUtil.js';
+
+  /** @type {{inAppNewVuln: boolean, inAppNewComment: boolean, pushNewVuln: boolean, pushNewComment: boolean}} */
+  let prefs = $state({
+    inAppNewVuln: true,
+    inAppNewComment: true,
+    pushNewVuln: true,
+    pushNewComment: true,
+  });
+  /** @type {string[]} */
+  let swimlaneUsers = $state([]);
+  let loaded = $state(false);
+  let saving = $state(false);
+  /** @type {Date | null} */
+  let lastSavedAt = $state(null);
+
+  onMount(async () => {
+    const settings = await Fetch('/api/profile/preferences');
+    if (settings) {
+      swimlaneUsers = settings.swimlaneUsers ?? [];
+      const np = settings.notificationPrefs ?? {};
+      // Server omits unset keys so they decode as undefined; treat undefined
+      // as "on" (the dispatcher's default).
+      prefs = {
+        inAppNewVuln: np.inAppNewVuln ?? true,
+        inAppNewComment: np.inAppNewComment ?? true,
+        pushNewVuln: np.pushNewVuln ?? true,
+        pushNewComment: np.pushNewComment ?? true,
+      };
+    }
+    loaded = true;
+  });
+
+  async function save() {
+    saving = true;
+    try {
+      await Fetch('/api/profile/preferences', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          swimlaneUsers,
+          notificationPrefs: prefs,
+        }),
+      });
+      lastSavedAt = new Date();
+    } finally {
+      saving = false;
+    }
+  }
+
+  /** @param {keyof typeof prefs} key */
+  function toggle(key) {
+    prefs[key] = !prefs[key];
+    save();
+  }
+</script>
+
+{#if loaded}
+<div class="card">
+  <div class="card-body">
+    <h3 class="card-title">Notification preferences</h3>
+    <p class="card-subtitle">Choose which events reach you, and on which channel. Everything is on by default. Web-push only applies to devices where you've enabled notifications.</p>
+
+    <div class="table-responsive">
+      <table class="table table-vcenter">
+        <thead>
+          <tr>
+            <th></th>
+            <th class="text-center">In-app</th>
+            <th class="text-center">Web push</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>New vulnerability</td>
+            <td class="text-center">
+              <label class="form-check form-check-single form-switch m-0">
+                <input class="form-check-input" type="checkbox" checked={prefs.inAppNewVuln} onchange={() => toggle('inAppNewVuln')} />
+              </label>
+            </td>
+            <td class="text-center">
+              <label class="form-check form-check-single form-switch m-0">
+                <input class="form-check-input" type="checkbox" checked={prefs.pushNewVuln} onchange={() => toggle('pushNewVuln')} />
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>New comment</td>
+            <td class="text-center">
+              <label class="form-check form-check-single form-switch m-0">
+                <input class="form-check-input" type="checkbox" checked={prefs.inAppNewComment} onchange={() => toggle('inAppNewComment')} />
+              </label>
+            </td>
+            <td class="text-center">
+              <label class="form-check form-check-single form-switch m-0">
+                <input class="form-check-input" type="checkbox" checked={prefs.pushNewComment} onchange={() => toggle('pushNewComment')} />
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="text-muted small mt-2">
+      {#if saving}
+        Saving…
+      {:else if lastSavedAt}
+        Saved {lastSavedAt.toLocaleTimeString()}
+      {/if}
+    </div>
+  </div>
+</div>
+{/if}

--- a/web/src/routes/(app)/settings/+page.svelte
+++ b/web/src/routes/(app)/settings/+page.svelte
@@ -11,6 +11,7 @@
 	import Auditlog from "$lib/components/settings/auditlog.svelte";
 	import { accessLevels } from "$lib/userStore";
 	import UserTable from "$lib/components/settings/UserTable.svelte";
+	import NotificationPrefs from "$lib/components/settings/notificationPrefs.svelte";
 
   let activeComponent = $state(Profile);
 
@@ -38,6 +39,7 @@
           <h4 class="subheader">Business settings</h4>
           <div class="list-group list-group-transparent">
             <a href="#" class:active="{activeComponent === Profile}" class="list-group-item list-group-item-action d-flex align-items-center" onclick={preventDefault(() => show(Profile))}>My Account</a>
+            <a href="#" class:active="{activeComponent === NotificationPrefs}" class="list-group-item list-group-item-action d-flex align-items-center" onclick={preventDefault(() => show(NotificationPrefs))}>Notifications</a>
             <a href="#" class:active="{activeComponent === APIKeys}" class="list-group-item list-group-item-action d-flex align-items-center" onclick={preventDefault(() => show(APIKeys))}>API keys</a>
             {#if $accessLevels["/vulnerability"].write}
             <a href="#" class:active="{activeComponent === ShareDocs}" class="list-group-item list-group-item-action" onclick={preventDefault(() => show(ShareDocs))}>Public Links</a>

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -1,11 +1,29 @@
-// Inside service-worker.js
+// Service worker for PRISM web-push.
+//
+// Two listeners:
+//  - push: renders the notification on screen.
+//  - notificationclick: focuses an existing window if there's one open at the
+//    target URL, otherwise opens a new one. We validate that the URL is a
+//    same-origin path before navigating so a malicious push payload can't
+//    redirect the user off-site.
+//  - pushsubscriptionchange: when the browser silently rotates or expires
+//    the subscription endpoint, re-subscribe with the cached VAPID key and
+//    POST the new subscription to the server so push keeps working without
+//    requiring the user to re-enable notifications.
+
 self.addEventListener('push', event => {
-  const data = event.data.json();
+  if (!event.data) return;
+  let data;
+  try {
+    data = event.data.json();
+  } catch (e) {
+    return;
+  }
   event.waitUntil(
-    self.registration.showNotification(data.title, {
-      body: data.body,
+    self.registration.showNotification(data.title || 'PRISM', {
+      body: data.body || '',
       image: data.icon,
-      data: { url: data.url }
+      data: { url: data.url || '/' }
     })
   );
 });
@@ -13,31 +31,74 @@ self.addEventListener('push', event => {
 self.addEventListener('notificationclick', function(event) {
   event.notification.close();
 
-  let dataUrl = event.notification.data.url;
-  const urlToOpen = new URL(dataUrl, self.location.origin).href;
+  const rawUrl = event.notification.data && event.notification.data.url;
+  // Only follow same-origin paths. Anything else is dropped — push payloads
+  // are server-trusted but defense-in-depth costs nothing here.
+  const safePath = (typeof rawUrl === 'string' && rawUrl.startsWith('/')) ? rawUrl : '/';
+  const urlToOpen = new URL(safePath, self.location.origin).href;
 
   const promiseChain = clients
-    .matchAll({
-      type: 'window',
-      includeUncontrolled: true,
-    })
+    .matchAll({ type: 'window', includeUncontrolled: true })
     .then((windowClients) => {
-      let matchingClient = null;
-
-      for (let i = 0; i < windowClients.length; i++) {
-        const windowClient = windowClients[i];
+      for (const windowClient of windowClients) {
         if (windowClient.url === urlToOpen) {
-          matchingClient = windowClient;
-          break;
+          return windowClient.focus();
         }
       }
-
-      if (matchingClient) {
-        return matchingClient.focus();
-      } else {
-        return clients.openWindow(urlToOpen);
-      }
+      return clients.openWindow(urlToOpen);
     });
 
   event.waitUntil(promiseChain);
 });
+
+// pushsubscriptionchange fires when the user-agent invalidates the existing
+// subscription (key rotation, quota cleanup, profile reset, etc.). Without
+// handling it, the browser silently stops receiving pushes until the user
+// next opens the app and the page-side button re-subscribes. We rebuild here
+// so notifications survive these rotations even when the tab is closed.
+self.addEventListener('pushsubscriptionchange', event => {
+  event.waitUntil(handlePushSubscriptionChange());
+});
+
+async function handlePushSubscriptionChange() {
+  const applicationServerKey = await getCachedVapidKey();
+  if (!applicationServerKey) return;
+  try {
+    const newSub = await self.registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey
+    });
+    await fetch('/api/notification/subscribe', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newSub)
+    });
+  } catch (e) {
+    // Either no permission, no network, or the server rejected — there's
+    // nothing the SW can do beyond logging. The page-side mount will retry
+    // on next visit.
+    console.warn('pushsubscriptionchange: re-subscribe failed', e);
+  }
+}
+
+// getCachedVapidKey reads from the keyval cache that the page-side script
+// keeps in IndexedDB-equivalent localStorage (mirrored into a SW-readable
+// cache by NotificationButton on subscribe). The SW has no localStorage, so
+// we fall back to fetching the public key from the API when no cache exists.
+async function getCachedVapidKey() {
+  try {
+    const cache = await caches.open('prism-notifications');
+    const hit = await cache.match('/__vapid');
+    if (hit) {
+      return await hit.text();
+    }
+  } catch (e) { /* fall through to network */ }
+  try {
+    const resp = await fetch('/api/notification/publicKey', { credentials: 'include' });
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces the disabled notification system with an endpoint-keyed push subscription model. Re-subscribing on a shared browser takes over the row, so the same physical device can only belong to one user at a time — fixes the cross-user push delivery bug that motivated turning the feature off.
- Moves in-app notifications off the racy `UserData.Notifications` JSON column onto a dedicated `notifications` table. Concurrent dispatchers can no longer lose-update each other.
- ACL-filters recipients at dispatch via `database.CanRecipientSeeVulnerability`, so users removed from a project after commenting stop receiving notifications about it.
- Adds per-user opt-out for `{in-app, push} × {new vuln, new comment}` stored in `UserData.Settings`, surfaced as a "Notifications" panel in the user settings menu.
- On first boot, the migration **wipes** legacy subscriber rows and the per-user notification JSON column rather than draining them — the pre-refactor data is the source of the misdelivery and was not worth carrying forward. Users re-subscribe through the new flow; the migration is idempotent thereafter.

## Stacked on
Base is `feat/vuln-attachments`, not `main`. The branch was cut off the attachments work and only contains notification commits.

## Notable behaviours kept by design
- **Web push survives logout.** Subscriptions are not torn down by `HandleLogout`; the frontend never calls `pushManager.unsubscribe()` on logout. Cross-user safety is enforced by take-over-on-subscribe rather than by killing subscriptions, so signing out doesn't stop the device from receiving pushes for that user.
- **Service worker handles `pushsubscriptionchange`** to keep delivery alive across silent browser-side endpoint rotation.

## Test plan
- [x] `go vet ./...`, `go build ./...`, `go test ./database/... ./routes/... ./models/...` clean in the devcontainer (the pre-existing `TestGetDashboardMetricsRespectsProjectAccess` failure due to missing `accessible_vulnerabilities` view in the bare test DB is unchanged from `main`).
- [x] `npm run check` error count matches baseline (1121); +1 warning from one extra `#` href on the new settings menu entry, same pattern as siblings.
- [x] Unit tests cover: take-over of shared endpoint, scoping of mark-read / delete to owner, multi-device push fanout, log-and-continue on per-device push errors, opt-out honoured per channel, migration idempotency, UNIQUE endpoint index enforcement, lost-update race on concurrent in-app writes (25 goroutines all land).