### PR TITLE
hotfix(web): repair markdown rendering and guard undefined criticality

### DIFF
--- a/web/src/lib/components/Markdown.svelte
+++ b/web/src/lib/components/Markdown.svelte
@@ -23,36 +23,33 @@ let checked = $state(0)
   /** @type {Props} */
   let { markdown = $bindable(""), writeAccess = false } = $props();
 
-// Add a custom renderer for tables
-renderer.table = function(header, body) {
-  return `<table class="">
-    <thead>${header}</thead>
-    ${body}</table>`;
+// marked v5+ passes token objects (not strings) to renderer methods.
+// Task-list checkboxes are emitted as a separate `checkbox` token inside the
+// list item's tokens; suppress the built-in one so our custom input is the only one.
+renderer.checkbox = function() {
+  return '';
 };
 
-renderer.listitem = function(text) {
-  if (text.includes("type=\"checkbox\"") == false){
-    return "<li>" + text + "</li>"
+renderer.listitem = function(item) {
+  const body = this.parser.parse(item.tokens);
+  if (!item.task) {
+    return `<li>${body}</li>`;
   }
-  // Assuming the text is in the format: '[ ] Item text' or '[x] Item text'
-  const isChecked = text.includes('checked');
-  if (isChecked) {
-    checked++
+  if (item.checked) {
+    checked++;
   }
   const isDisabled = !writeAccess; // Modify as needed
-  let itemText = text.replace(/^\[\s?x?\]\s?/, '');
-  itemText = itemText.replace(/<input [^>]*type="checkbox"[^>]*>\s*/, '');
-
   return `
     <label class="form-check" data-index="${todo++}">
-      <input class="form-check-input" type="checkbox" ${isChecked ? 'checked' : ''} ${isDisabled ? 'disabled' : ''}>
-      <span class="form-check-label">${itemText}</span>
+      <input class="form-check-input" type="checkbox" ${item.checked ? 'checked' : ''} ${isDisabled ? 'disabled' : ''}>
+      <span class="form-check-label">${body.trim()}</span>
     </label>
   `;
 };
 
 // Add a custom renderer for links
-renderer.link = function(href, title, text) {
+renderer.link = function({ href, title, tokens }) {
+  const text = this.parser.parseInline(tokens);
   // Ensure the href has the 'https://' prefix
   if (!href.startsWith('http://') && !href.startsWith('https://')) {
     href = 'https://' + href;

--- a/web/src/lib/components/charts/CriticalityPie.svelte
+++ b/web/src/lib/components/charts/CriticalityPie.svelte
@@ -102,7 +102,7 @@
       severityData = { critical: 0, high: 0, medium: 0, low: 0, information: 0 };
 
       vulnerabilities.forEach(vulnerability => {
-        const criticality = vulnerability.Vulnerability.criticality.toLowerCase();
+        const criticality = (vulnerability.Vulnerability?.criticality || '').toLowerCase();
 
         if (criticality === 'critical') {
           severityData.critical += 1;

--- a/web/src/lib/components/dashboard/Criticality.svelte
+++ b/web/src/lib/components/dashboard/Criticality.svelte
@@ -44,7 +44,7 @@
 	    severityData = { critical: 0, high: 0, medium: 0, low: 0, information: 0 };
 
 	    vulnerabilities.forEach(vulnerability => {
-	      const criticality = vulnerability.Vulnerability.criticality.toLowerCase();
+	      const criticality = (vulnerability.Vulnerability?.criticality || '').toLowerCase();
 
 	      if (criticality === 'critical') {
 	        severityData.critical += 1;

--- a/web/src/lib/components/dashboard/OwaspBarChart.svelte
+++ b/web/src/lib/components/dashboard/OwaspBarChart.svelte
@@ -20,7 +20,7 @@
 
     vulns.forEach(item => {
       const category = item.Vulnerability.category || '';
-      const criticality = item.Vulnerability.criticality.toLowerCase();
+      const criticality = (item.Vulnerability?.criticality || '').toLowerCase();
 
       if (!(category in results)) {
         results[category] = { information: 0, low: 0, medium: 0, high: 0, critical: 0 };

--- a/web/src/lib/components/dashboard/OwaspTable.svelte
+++ b/web/src/lib/components/dashboard/OwaspTable.svelte
@@ -20,7 +20,7 @@
 
     vulns.forEach(item => {
       const category = item.Vulnerability.category || '';
-      const criticality = item.Vulnerability.criticality.toLowerCase();
+      const criticality = (item.Vulnerability?.criticality || '').toLowerCase();
 
       if (!(category in results)) {
         results[category] = { information: 0, low: 0, medium: 0, high: 0, critical: 0 };

--- a/web/src/routes/(app)/project/[id]/view/+page.svelte
+++ b/web/src/routes/(app)/project/[id]/view/+page.svelte
@@ -32,7 +32,7 @@
 
     apiResponse.forEach(item => {
       const category = item.Vulnerability.category || '';
-      const criticality = item.Vulnerability.criticality.toLowerCase();
+      const criticality = (item.Vulnerability?.criticality || '').toLowerCase();
 
       if (!(category in results)) {
         results[category] = { information: 0, low: 0, medium: 0, high: 0, critical: 0 };
@@ -87,7 +87,7 @@ let severityData = $state({
     severityData = { critical: 0, high: 0, medium: 0, low: 0, information: 0 };
 
     vulnerabilities.forEach(vulnerability => {
-      const criticality = vulnerability.Vulnerability.criticality.toLowerCase();
+      const criticality = (vulnerability.Vulnerability?.criticality || '').toLowerCase();
 
       if (criticality === 'critical') {
         severityData.critical += 1;


### PR DESCRIPTION
## Summary
Hotfix for two runtime errors on the project view page.

**1. Markdown rendering crash (`t.includes is not a function`)**
`marked` v18 passes token *objects* (not strings) to renderer methods, so the custom `listitem`/`table`/`link` renderers in `Markdown.svelte` broke. Fixed:
- `listitem` and `link` rewritten for the v18 token API (`this.parser.parse` / `parseInline`).
- Task checkboxes are now a separate `checkbox` token inside the item; the built-in one is suppressed so our custom `<input>` isn't rendered twice.
- Dropped the custom `table` renderer (it only added an empty `class=""` and omitted `<tbody>`) in favor of marked's default — `tbody` is already in the DOMPurify allowlist.

**2. `criticality.toLowerCase()` on undefined**
Guarded all 6 call sites with `(… || '').toLowerCase()` (matches the default-value pattern already used elsewhere) across the project view page and its `CriticalityPie`, `Criticality`, `OwaspTable`, `OwaspBarChart` children.

## Testing
- Verified the rewritten renderers against the real `marked` v18 with a Node script: task lists (single checkbox, correct checked state, inline markdown preserved, todo/done counts correct), links (`https://` prefix + `target`/`rel`), and tables (`thead`/`tbody`) all render without error.
- Note: a full Vite build was not run on the host — local `node_modules` carries the devcontainer's Linux rollup binary, so building requires the devcontainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)